### PR TITLE
utils: validate Savgol window length

### DIFF
--- a/src/mtdata/utils/denoise/filters/polynomial.py
+++ b/src/mtdata/utils/denoise/filters/polynomial.py
@@ -40,6 +40,11 @@ def _denoise_savgol_series(
     if window % 2 == 0:
         window += 1
     if window > len(x):
+        _logger.warning(
+            "savgol window_length (%d) must not exceed series length (%d)",
+            window,
+            len(x),
+        )
         raise ValueError(
             f"savgol window_length ({window}) must not exceed series length ({len(x)})"
         )

--- a/src/mtdata/utils/denoise/filters/polynomial.py
+++ b/src/mtdata/utils/denoise/filters/polynomial.py
@@ -39,6 +39,10 @@ def _denoise_savgol_series(
         return s
     if window % 2 == 0:
         window += 1
+    if window > len(x):
+        raise ValueError(
+            f"savgol window_length ({window}) must not exceed series length ({len(x)})"
+        )
     polyorder = int(params.get('polyorder', 2))
     polyorder = max(0, min(polyorder, window - 1))
     mode = str(params.get('mode', 'interp'))

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -286,6 +286,13 @@ class TestDenoiseSeriesDispatch:
         _check_basic(result.values, N)
         assert _smoothness(result.values) <= _smoothness(NOISY_SIGNAL)
 
+    def test_savgol_rejects_window_longer_than_series(self):
+        pytest.importorskip("scipy.signal")
+        s = _make_series(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+
+        with pytest.raises(ValueError, match="window_length"):
+            _denoise_series(s, method="savgol", params={"window": 9, "polyorder": 2})
+
     def test_gaussian(self):
         pytest.importorskip("scipy.ndimage")
         s = _make_series(NOISY_SIGNAL)


### PR DESCRIPTION
## Summary of the issue
Savitzky-Golay denoising accepted window values larger than the input series length and then silently fell back to the original series after SciPy raised.

## Root cause
`_denoise_savgol_series()` normalized small/even windows, but it never validated the final window length against `len(x)` before calling `savgol_filter()`. The resulting exception was caught and converted into a silent identity return.

## Implemented solution
- added an explicit `window > len(x)` check in `src/mtdata/utils/denoise/filters/polynomial.py`
- raised a clear `ValueError` for oversized Savgol windows before calling SciPy
- added regression coverage in `tests/utils/test_denoise_pure.py`

## Trade-offs or limitations
This change is intentionally scoped to direct Savgol window-length validation; `_apply_denoise()` still preserves its broader swallow-and-continue behavior for other denoise failures.

## Report reference
- `code-reports/to-do/06-savgol-window-validation.md`