### PR TITLE
core: infer direction from take-profit

### DIFF
--- a/src/mtdata/core/trading_use_cases.py
+++ b/src/mtdata/core/trading_use_cases.py
@@ -69,7 +69,7 @@ def _resolve_trade_risk_direction(
         "Unable to infer trade direction when proposed_sl equals proposed_entry "
         "and proposed_tp is missing or also equals proposed_entry. "
         "Provide direction='long' or direction='short'.",
-        "inferred_from_stop_loss",
+        "unable_to_infer",
     )
 
 

--- a/src/mtdata/core/trading_use_cases.py
+++ b/src/mtdata/core/trading_use_cases.py
@@ -49,6 +49,7 @@ def _resolve_trade_risk_direction(
     direction: Any,
     entry: float,
     stop_loss: float,
+    take_profit: float | None = None,
 ) -> tuple[str | None, str | None, str]:
     direction_text = str(direction).strip() if direction is not None else ""
     if direction_text:
@@ -58,9 +59,15 @@ def _resolve_trade_risk_direction(
         return "long", None, "inferred_from_stop_loss"
     if stop_loss > entry:
         return "short", None, "inferred_from_stop_loss"
+    if take_profit is not None:
+        if take_profit > entry:
+            return "long", None, "inferred_from_take_profit"
+        if take_profit < entry:
+            return "short", None, "inferred_from_take_profit"
     return (
         None,
-        "Unable to infer trade direction when proposed_sl equals proposed_entry. "
+        "Unable to infer trade direction when proposed_sl equals proposed_entry "
+        "and proposed_tp is missing or also equals proposed_entry. "
         "Provide direction='long' or direction='short'.",
         "inferred_from_stop_loss",
     )
@@ -74,12 +81,12 @@ def _validate_trade_risk_levels(
     take_profit: float | None,
 ) -> str | None:
     if direction == "long":
-        if stop_loss >= entry:
+        if stop_loss > entry:
             return "For long trades, proposed_sl must be below proposed_entry."
         if take_profit is not None and take_profit <= entry:
             return "For long trades, proposed_tp must be above proposed_entry."
         return None
-    if stop_loss <= entry:
+    if stop_loss < entry:
         return "For short trades, proposed_sl must be above proposed_entry."
     if take_profit is not None and take_profit >= entry:
         return "For short trades, proposed_tp must be below proposed_entry."
@@ -1264,6 +1271,9 @@ def run_trade_risk_analyze(
                     direction=request.direction,
                     entry=float(request.proposed_entry),
                     stop_loss=float(request.proposed_sl),
+                    take_profit=float(request.proposed_tp)
+                    if request.proposed_tp is not None
+                    else None,
                 )
                 if direction_error or direction_norm is None:
                     result["position_sizing_error"] = (
@@ -1318,6 +1328,10 @@ def run_trade_risk_analyze(
                     if direction_source == "inferred_from_stop_loss":
                         sizing_notes.append(
                             "Direction was inferred from stop-loss placement."
+                        )
+                    elif direction_source == "inferred_from_take_profit":
+                        sizing_notes.append(
+                            "Direction was inferred from take-profit placement because stop-loss matched entry."
                         )
 
                     step_txt = f"{volume_step:.10f}".rstrip("0")

--- a/tests/trading/test_trading_risk_business_logic.py
+++ b/tests/trading/test_trading_risk_business_logic.py
@@ -8,7 +8,7 @@ import sys
 from mtdata.core import trading_risk as core_trading_risk
 from mtdata.core.trading import trade_risk_analyze as _trade_risk_analyze_tool
 from mtdata.core.trading_requests import TradeRiskAnalyzeRequest
-from mtdata.core.trading_use_cases import run_trade_risk_analyze
+from mtdata.core.trading_use_cases import _resolve_trade_risk_direction, run_trade_risk_analyze
 from mtdata.utils.mt5 import MT5ConnectionError
 
 
@@ -124,6 +124,45 @@ def test_trade_risk_analyze_accepts_explicit_short_direction() -> None:
     assert sizing["risk_pct"] <= 1.0
     assert sizing["risk_compliance"] == "within_requested_risk"
     assert sizing["rr_ratio"] == 1.0
+
+
+def test_resolve_trade_risk_direction_uses_take_profit_when_stop_equals_entry() -> None:
+    direction_norm, direction_error, direction_source = _resolve_trade_risk_direction(
+        direction=None,
+        entry=100.0,
+        stop_loss=100.0,
+        take_profit=110.0,
+    )
+
+    assert direction_norm == "long"
+    assert direction_error is None
+    assert direction_source == "inferred_from_take_profit"
+
+
+def test_trade_risk_analyze_falls_back_to_take_profit_direction_for_break_even_stop() -> None:
+    mt5 = MagicMock()
+    prev = sys.modules.get("MetaTrader5")
+    sys.modules["MetaTrader5"] = mt5
+    mt5.account_info.return_value = SimpleNamespace(equity=1000.0, currency="USD")
+    mt5.positions_get.return_value = []
+    mt5.symbol_info.return_value = _make_symbol_info()
+
+    out = trade_risk_analyze(
+        symbol="EURUSD",
+        desired_risk_pct=1.0,
+        proposed_entry=100.0,
+        proposed_sl=100.0,
+        proposed_tp=110.0,
+    )
+
+    if prev is not None:
+        sys.modules["MetaTrader5"] = prev
+
+    assert (
+        out["position_sizing_error"]
+        == "SL distance must be greater than 0"
+    )
+    assert "Unable to infer trade direction" not in out["position_sizing_error"]
 
 
 def test_trade_risk_analyze_rejects_wrong_side_stop_for_short_trade() -> None:

--- a/tests/trading/test_trading_risk_business_logic.py
+++ b/tests/trading/test_trading_risk_business_logic.py
@@ -139,6 +139,19 @@ def test_resolve_trade_risk_direction_uses_take_profit_when_stop_equals_entry() 
     assert direction_source == "inferred_from_take_profit"
 
 
+def test_resolve_trade_risk_direction_uses_take_profit_when_stop_equals_entry_short() -> None:
+    direction_norm, direction_error, direction_source = _resolve_trade_risk_direction(
+        direction=None,
+        entry=100.0,
+        stop_loss=100.0,
+        take_profit=90.0,
+    )
+
+    assert direction_norm == "short"
+    assert direction_error is None
+    assert direction_source == "inferred_from_take_profit"
+
+
 def test_trade_risk_analyze_falls_back_to_take_profit_direction_for_break_even_stop() -> None:
     mt5 = MagicMock()
     prev = sys.modules.get("MetaTrader5")
@@ -147,16 +160,19 @@ def test_trade_risk_analyze_falls_back_to_take_profit_direction_for_break_even_s
     mt5.positions_get.return_value = []
     mt5.symbol_info.return_value = _make_symbol_info()
 
-    out = trade_risk_analyze(
-        symbol="EURUSD",
-        desired_risk_pct=1.0,
-        proposed_entry=100.0,
-        proposed_sl=100.0,
-        proposed_tp=110.0,
-    )
-
-    if prev is not None:
-        sys.modules["MetaTrader5"] = prev
+    try:
+        out = trade_risk_analyze(
+            symbol="EURUSD",
+            desired_risk_pct=1.0,
+            proposed_entry=100.0,
+            proposed_sl=100.0,
+            proposed_tp=110.0,
+        )
+    finally:
+        if prev is not None:
+            sys.modules["MetaTrader5"] = prev
+        else:
+            sys.modules.pop("MetaTrader5", None)
 
     assert (
         out["position_sizing_error"]


### PR DESCRIPTION
## Summary of the issue
`trade_risk_analyze` could not resolve direction when `proposed_sl == proposed_entry`, even when take-profit placement made the trade side obvious.

## Root cause
`_resolve_trade_risk_direction()` only inferred direction from the stop-loss side of entry. When stop-loss matched entry exactly, the function returned an inference error before later validation could use `proposed_tp` or the zero-distance guard.

## Implemented solution
- added `take_profit` fallback inference in `src/mtdata/core/trading_use_cases.py`
- allowed equal-stop cases to pass the stop-side validator so they reach the existing `SL distance must be greater than 0` sizing guard
- added focused regression coverage in `tests/trading/test_trading_risk_business_logic.py`

## Trade-offs or limitations
Break-even-stop sizing still does not produce a position size, because zero stop distance remains invalid for risk-based sizing. The change is limited to resolving direction and surfacing the more accurate downstream validation error.

## Report reference
- `code-reports/to-do/issue-05-trading-direction-inference-edge-case.md`