### PR TITLE
forecast: remove ensemble dispatch state

### DIFF
--- a/src/mtdata/forecast/forecast_engine.py
+++ b/src/mtdata/forecast/forecast_engine.py
@@ -2,11 +2,10 @@
 Forecast engine core logic and orchestration.
 """
 
-from typing import Any, Dict, Optional, List, Literal, Tuple
+from typing import Any, Callable, Dict, Optional, List, Literal, Tuple
 import logging
 import numpy as np
 import pandas as pd
-import math
 
 from ..bootstrap.settings import mt5_config
 from ..shared.constants import TIMEFRAME_MAP, TIMEFRAME_SECONDS
@@ -75,35 +74,50 @@ _ENSEMBLE_BASE_METHODS = (
 logger = logging.getLogger(__name__)
 
 
-def _clear_ensemble_dispatch_error() -> None:
+def _build_ensemble_dispatch_error(method_name: str, exc: BaseException) -> Dict[str, Any]:
+    return {
+        "method": str(method_name),
+        "error": str(exc),
+        "error_type": type(exc).__name__,
+    }
+
+
+def _consume_dispatch_callback_error(
+    dispatch_method: Any,
+    *,
+    method_name: str,
+) -> Optional[Dict[str, Any]]:
     try:
-        setattr(_ensemble_dispatch_method, "_last_error", None)
-    except Exception:
-        pass
-
-
-def _record_ensemble_dispatch_error(method_name: str, exc: BaseException) -> None:
-    try:
-        setattr(
-            _ensemble_dispatch_method,
-            "_last_error",
-            {
-                "method": str(method_name),
-                "error": str(exc),
-                "error_type": type(exc).__name__,
-            },
-        )
-    except Exception:
-        pass
-
-
-def _consume_ensemble_dispatch_error() -> Optional[Dict[str, Any]]:
-    try:
-        error = getattr(_ensemble_dispatch_method, "_last_error", None)
+        error = getattr(dispatch_method, "_last_error", None)
     except Exception:
         return None
-    _clear_ensemble_dispatch_error()
-    return dict(error) if isinstance(error, dict) else None
+    try:
+        setattr(dispatch_method, "_last_error", None)
+    except Exception:
+        pass
+    if not isinstance(error, dict):
+        return None
+    payload = dict(error)
+    payload.setdefault("method", str(method_name))
+    return payload
+
+
+def _dispatch_ensemble_callback_with_error(
+    dispatch_method: Callable[[str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]], Optional[np.ndarray]],
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    method_l = str(method_name).lower().strip()
+    try:
+        forecast = dispatch_method(method_l, series, horizon, seasonality, params)
+    except Exception as ex:
+        return None, _build_ensemble_dispatch_error(method_l, ex)
+    if forecast is None:
+        return None, _consume_dispatch_callback_error(dispatch_method, method_name=method_l)
+    return forecast, None
 
 
 def _append_ensemble_failure(
@@ -150,6 +164,25 @@ def _normalize_weights(weights: Any, size: int) -> Optional[np.ndarray]:
     return arr / total
 
 
+def _ensemble_dispatch_method_impl(
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    """Run a supported ensemble base method with safe fallbacks."""
+
+    m = str(method_name).lower().strip()
+    method_params = dict(params or {})
+    try:
+        forecaster = ForecastRegistry.get(m)
+        res = forecaster.forecast(series, horizon, seasonality or 1, method_params)
+        return res.forecast, None
+    except Exception as ex:
+        return None, _build_ensemble_dispatch_error(m, ex)
+
+
 def _ensemble_dispatch_method(
     method_name: str,
     series: pd.Series,
@@ -157,20 +190,43 @@ def _ensemble_dispatch_method(
     seasonality: Optional[int],
     params: Optional[Dict[str, Any]],
 ) -> Optional[np.ndarray]:
-    """Run a supported ensemble base method with safe fallbacks."""
+    forecast, _ = _ensemble_dispatch_method_impl(
+        method_name,
+        series,
+        horizon,
+        seasonality,
+        params,
+    )
+    return forecast
 
-    m = str(method_name).lower().strip()
-    # Allow any registered method in ensemble if it supports what we need
-    # But for safety/speed, we might restrict to fast methods or check registry
-    _clear_ensemble_dispatch_error()
-    method_params = dict(params or {})
-    try:
-        forecaster = ForecastRegistry.get(m)
-        res = forecaster.forecast(series, horizon, seasonality or 1, method_params)
-        return res.forecast
-    except Exception as ex:
-        _record_ensemble_dispatch_error(m, ex)
-        return None
+
+_DEFAULT_ENSEMBLE_DISPATCH_METHOD = _ensemble_dispatch_method
+
+
+def _ensemble_dispatch_with_error(
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    dispatch_method = globals().get("_ensemble_dispatch_method")
+    if callable(dispatch_method) and dispatch_method is not _DEFAULT_ENSEMBLE_DISPATCH_METHOD:
+        return _dispatch_ensemble_callback_with_error(
+            dispatch_method,
+            method_name,
+            series,
+            horizon,
+            seasonality,
+            params,
+        )
+    return _ensemble_dispatch_method_impl(
+        method_name,
+        series,
+        horizon,
+        seasonality,
+        params,
+    )
 
 
 def _prepare_ensemble_cv(
@@ -206,13 +262,19 @@ def _prepare_ensemble_cv(
         row_forecasts: List[np.ndarray] = []
         success = True
         for m in methods:
-            fc = _ensemble_dispatch_method(m, train, horizon, seasonality, params_map.get(m, {}))
+            fc, error_detail = _ensemble_dispatch_with_error(
+                m,
+                train,
+                horizon,
+                seasonality,
+                params_map.get(m, {}),
+            )
             if fc is None:
                 _append_ensemble_failure(
                     failure_sink,
                     method_name=m,
                     anchor_index=idx,
-                    error_detail=_consume_ensemble_dispatch_error()
+                    error_detail=error_detail
                     or {"error": "Component forecast unavailable", "error_type": "forecast_unavailable"},
                 )
                 success = False
@@ -689,7 +751,6 @@ def forecast_engine(
     """
     try:
         ci_values = None
-        ensemble_meta: Dict[str, Any] = {}
         # Coerce CLI string inputs to proper types
         try:
             horizon = int(horizon) if horizon is not None else 12

--- a/src/mtdata/forecast/methods/ensemble.py
+++ b/src/mtdata/forecast/methods/ensemble.py
@@ -35,35 +35,46 @@ def _normalize_weights_default(weights: Any, size: int) -> Optional[np.ndarray]:
     return arr / total
 
 
-def _clear_dispatch_error(dispatch_method: Any) -> None:
-    try:
-        setattr(dispatch_method, "_last_error", None)
-    except Exception:
-        pass
+def _build_dispatch_error(method_name: str, exc: BaseException) -> Dict[str, Any]:
+    return {
+        "method": str(method_name),
+        "error": str(exc),
+        "error_type": type(exc).__name__,
+    }
 
 
-def _record_dispatch_error(dispatch_method: Any, method_name: str, exc: BaseException) -> None:
-    try:
-        setattr(
-            dispatch_method,
-            "_last_error",
-            {
-                "method": str(method_name),
-                "error": str(exc),
-                "error_type": type(exc).__name__,
-            },
-        )
-    except Exception:
-        pass
-
-
-def _consume_dispatch_error(dispatch_method: Any) -> Optional[Dict[str, Any]]:
+def _consume_dispatch_error(dispatch_method: Any, *, method_name: str) -> Optional[Dict[str, Any]]:
     try:
         error = getattr(dispatch_method, "_last_error", None)
     except Exception:
         return None
-    _clear_dispatch_error(dispatch_method)
-    return dict(error) if isinstance(error, dict) else None
+    try:
+        setattr(dispatch_method, "_last_error", None)
+    except Exception:
+        pass
+    if not isinstance(error, dict):
+        return None
+    payload = dict(error)
+    payload.setdefault("method", str(method_name))
+    return payload
+
+
+def _dispatch_callback_with_error(
+    dispatch_method: Callable[[str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]], Optional[np.ndarray]],
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    method_l = str(method_name).lower().strip()
+    try:
+        forecast = dispatch_method(method_l, series, horizon, seasonality, params)
+    except Exception as ex:
+        return None, _build_dispatch_error(method_l, ex)
+    if forecast is None:
+        return None, _consume_dispatch_error(dispatch_method, method_name=method_l)
+    return forecast, None
 
 
 def _append_failure(
@@ -107,6 +118,22 @@ def _stabilized_bma_weights(rmse: np.ndarray) -> Optional[np.ndarray]:
     return weights / total
 
 
+def _ensemble_dispatch_method_default_impl(
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    method_l = str(method_name).lower().strip()
+    try:
+        forecaster = ForecastRegistry.get(method_l)
+        res = forecaster.forecast(series, horizon, seasonality or 1, dict(params or {}))
+        return res.forecast, None
+    except Exception as ex:
+        return None, _build_dispatch_error(method_l, ex)
+
+
 def _ensemble_dispatch_method_default(
     method_name: str,
     series: pd.Series,
@@ -114,15 +141,33 @@ def _ensemble_dispatch_method_default(
     seasonality: Optional[int],
     params: Optional[Dict[str, Any]],
 ) -> Optional[np.ndarray]:
-    method_l = str(method_name).lower().strip()
-    _clear_dispatch_error(_ensemble_dispatch_method_default)
-    try:
-        forecaster = ForecastRegistry.get(method_l)
-        res = forecaster.forecast(series, horizon, seasonality or 1, dict(params or {}))
-        return res.forecast
-    except Exception as ex:
-        _record_dispatch_error(_ensemble_dispatch_method_default, method_l, ex)
-        return None
+    forecast, _ = _ensemble_dispatch_method_default_impl(
+        method_name,
+        series,
+        horizon,
+        seasonality,
+        params,
+    )
+    return forecast
+
+
+_DEFAULT_DISPATCH_METHOD = _ensemble_dispatch_method_default
+
+
+def _ensemble_dispatch_method_default_with_error(
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    return _ensemble_dispatch_method_default_impl(
+        method_name,
+        series,
+        horizon,
+        seasonality,
+        params,
+    )
 
 
 def _prepare_ensemble_cv_default(
@@ -133,7 +178,10 @@ def _prepare_ensemble_cv_default(
     params_map: Dict[str, Dict[str, Any]],
     cv_points: int,
     min_train: int,
-    dispatch_method: Callable[[str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]], Optional[np.ndarray]],
+    dispatch_with_error: Callable[
+        [str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]],
+        Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]],
+    ],
     failure_sink: Optional[List[Dict[str, Any]]] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     n = len(series)
@@ -157,14 +205,20 @@ def _prepare_ensemble_cv_default(
         row_forecasts: List[np.ndarray] = []
         success = True
         for method_name in methods:
-            fc = dispatch_method(method_name, train, horizon, seasonality, params_map.get(method_name, {}))
+            fc, error_detail = dispatch_with_error(
+                method_name,
+                train,
+                horizon,
+                seasonality,
+                params_map.get(method_name, {}),
+            )
             if fc is None:
                 _append_failure(
                     failure_sink,
                     stage="cv",
                     method_name=method_name,
                     anchor_index=idx,
-                    error_detail=_consume_dispatch_error(dispatch_method)
+                    error_detail=error_detail
                     or {"error": "Component forecast unavailable", "error_type": "forecast_unavailable"},
                 )
                 success = False
@@ -243,6 +297,7 @@ class EnsembleMethod(ForecastMethod):
 
         call_kwargs_out = dict(call_kwargs)
         call_kwargs_out["ensemble_dispatch_method"] = _forecast_engine._ensemble_dispatch_method
+        call_kwargs_out["ensemble_dispatch_with_error"] = _forecast_engine._ensemble_dispatch_with_error
         call_kwargs_out["prepare_ensemble_cv"] = _forecast_engine._prepare_ensemble_cv
         call_kwargs_out["normalize_weights"] = _forecast_engine._normalize_weights
         call_kwargs_out["get_available_methods"] = _forecast_engine._get_available_methods
@@ -260,6 +315,28 @@ class EnsembleMethod(ForecastMethod):
         dispatch_method = kwargs.get("ensemble_dispatch_method")
         if not callable(dispatch_method):
             dispatch_method = _ensemble_dispatch_method_default
+        dispatch_with_error = kwargs.get("ensemble_dispatch_with_error")
+        if not callable(dispatch_with_error):
+            if dispatch_method is _DEFAULT_DISPATCH_METHOD:
+                dispatch_with_error = _ensemble_dispatch_method_default_with_error
+            else:
+                def _dispatch_with_error(
+                    method_name: str,
+                    series_in: pd.Series,
+                    horizon_in: int,
+                    seasonality_in: Optional[int],
+                    params_in: Optional[Dict[str, Any]],
+                ) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+                    return _dispatch_callback_with_error(
+                        dispatch_method,
+                        method_name,
+                        series_in,
+                        horizon_in,
+                        seasonality_in,
+                        params_in,
+                    )
+
+                dispatch_with_error = _dispatch_with_error
 
         cv_failures: List[Dict[str, Any]] = []
         component_failures: List[Dict[str, Any]] = []
@@ -270,14 +347,14 @@ class EnsembleMethod(ForecastMethod):
                 return _prepare_ensemble_cv_default(
                     series_in,
                     methods,
-                    horizon_in,
-                    seasonality_in,
-                    params_map,
-                    cv_points,
-                    min_train,
-                    dispatch_method,
-                    failure_sink=cv_failures,
-                )
+                        horizon_in,
+                        seasonality_in,
+                        params_map,
+                        cv_points,
+                        min_train,
+                        dispatch_with_error,
+                        failure_sink=cv_failures,
+                    )
             prepare_cv = _prepare
 
         normalize_weights = kwargs.get("normalize_weights")
@@ -369,13 +446,19 @@ class EnsembleMethod(ForecastMethod):
         component_methods: List[str] = []
         component_forecasts: List[np.ndarray] = []
         for method_name in base_methods:
-            fc = dispatch_method(method_name, series, horizon, seasonality, params_map.get(method_name, {}))
+            fc, error_detail = dispatch_with_error(
+                method_name,
+                series,
+                horizon,
+                seasonality,
+                params_map.get(method_name, {}),
+            )
             if fc is None:
                 _append_failure(
                     component_failures,
                     stage="component",
                     method_name=method_name,
-                    error_detail=_consume_dispatch_error(dispatch_method)
+                    error_detail=error_detail
                     or {"error": "Component forecast unavailable", "error_type": "forecast_unavailable"},
                 )
                 continue

--- a/tests/forecast/test_ensemble_method_business_logic.py
+++ b/tests/forecast/test_ensemble_method_business_logic.py
@@ -71,6 +71,30 @@ def test_ensemble_reports_component_failures():
     assert out.metadata["component_failures"][0]["error"] == "boom"
 
 
+def test_ensemble_reports_component_failures_from_dispatch_exceptions():
+    series = pd.Series(np.linspace(1.0, 20.0, 20))
+    method = em.EnsembleMethod()
+
+    def dispatch(method_name, series_in, horizon, seasonality, params):
+        if method_name == "bad":
+            raise RuntimeError("boom")
+        return np.array([5.0, 6.0], dtype=float)
+
+    out = method.forecast(
+        series,
+        horizon=2,
+        seasonality=1,
+        params={"methods": ["naive", "bad"], "mode": "average"},
+        ensemble_dispatch_method=dispatch,
+        get_available_methods=lambda: ("naive", "bad"),
+    )
+
+    assert np.allclose(out.forecast, [5.0, 6.0])
+    assert out.metadata["component_failures"][0]["method"] == "bad"
+    assert out.metadata["component_failures"][0]["error"] == "boom"
+    assert out.metadata["component_failures"][0]["error_type"] == "RuntimeError"
+
+
 def test_ensemble_prepare_forecast_call_injects_engine_helpers():
     method = em.EnsembleMethod()
     context = ForecastCallContext(
@@ -94,6 +118,7 @@ def test_ensemble_prepare_forecast_call_injects_engine_helpers():
 
     assert params == {"methods": ["naive"]}
     assert kwargs["ensemble_dispatch_method"] is fe._ensemble_dispatch_method
+    assert kwargs["ensemble_dispatch_with_error"] is fe._ensemble_dispatch_with_error
     assert kwargs["prepare_ensemble_cv"] is fe._prepare_ensemble_cv
     assert kwargs["normalize_weights"] is fe._normalize_weights
     assert kwargs["get_available_methods"] is fe._get_available_methods

--- a/tests/forecast/test_forecast_engine_business_logic.py
+++ b/tests/forecast/test_forecast_engine_business_logic.py
@@ -210,27 +210,46 @@ def test_prepare_ensemble_cv_uses_all_horizon_steps(monkeypatch):
     assert y.tolist() == [7.0, 8.0, 8.0, 9.0]
 
 
-def test_prepare_ensemble_cv_uses_all_horizon_steps(monkeypatch):
-    series = pd.Series(np.arange(1.0, 11.0))
+def test_prepare_ensemble_cv_records_dispatch_errors_without_function_state(monkeypatch):
+    class GoodForecaster:
+        def forecast(self, series, horizon, seasonality, params):
+            return ForecastResult(
+                forecast=np.array([float(series.iloc[-1] + 1.0)], dtype=float),
+                params_used={},
+                metadata={},
+            )
 
-    def fake_dispatch(method_name, train, horizon, seasonality, params):
-        base = float(train.iloc[-1])
-        return np.array([base + 1.0, base + 2.0], dtype=float)
+    class BadForecaster:
+        def forecast(self, series, horizon, seasonality, params):
+            raise RuntimeError("boom")
 
-    monkeypatch.setattr(fe, "_ensemble_dispatch_method", fake_dispatch)
+    class FakeRegistry:
+        @staticmethod
+        def get(name):
+            if name == "bad":
+                return BadForecaster()
+            return GoodForecaster()
 
+    monkeypatch.setattr(fe, "ForecastRegistry", FakeRegistry)
+
+    failures = []
     x, y = fe._prepare_ensemble_cv(
-        series=series,
-        methods=["naive", "theta"],
-        horizon=2,
+        series=pd.Series(np.arange(1.0, 10.0)),
+        methods=["bad", "naive"],
+        horizon=1,
         seasonality=1,
         params_map={},
-        cv_points=2,
+        cv_points=1,
         min_train=3,
+        failure_sink=failures,
     )
 
-    assert x.shape == (4, 2)
-    assert y.tolist() == [7.0, 8.0, 8.0, 9.0]
+    assert x.shape == (0, 2)
+    assert y.shape == (0,)
+    assert failures[0]["method"] == "bad"
+    assert failures[0]["error"] == "boom"
+    assert failures[0]["error_type"] == "RuntimeError"
+    assert getattr(fe._ensemble_dispatch_method, "_last_error", None) is None
 
 
 def test_forecast_engine_validation_and_top_level_errors(monkeypatch):


### PR DESCRIPTION
## Summary of the issue
Forecast ensemble dispatch kept the most recent exception on the `_ensemble_dispatch_method` function object, which was mutable shared state across calls.

## Root cause
`src/mtdata/forecast/forecast_engine.py` recorded dispatch failures by mutating `_ensemble_dispatch_method._last_error` and then consumed that side channel later in CV and component aggregation. That state could leak across concurrent or re-entrant execution.

## Implemented solution
- replaced function-object error state in `forecast_engine.py` with explicit `(forecast, error_detail)` dispatch helpers
- threaded the same explicit error-detail flow through `src/mtdata/forecast/methods/ensemble.py` so the registered ensemble method still captures component and CV failures
- added regression coverage for dispatch exceptions and helper injection in the forecast ensemble tests

## Trade-offs or limitations
Custom external dispatch callbacks can still expose `_last_error` metadata if they choose, and the ensemble method will consume it for compatibility. The built-in forecast-engine and default ensemble dispatch paths no longer depend on that mutable side channel.

## Report reference
- `code-reports/to-do/09-ensemble-dispatch-error.md`