### PR TITLE
core: drop dead unwrap helper

### DIFF
--- a/src/mtdata/core/report_templates/basic.py
+++ b/src/mtdata/core/report_templates/basic.py
@@ -186,12 +186,6 @@ def _parse_table_data(table_lines: List[str]) -> Any:
     except Exception:
         return table_lines
 
-
-def _unwrap_mcp_function(func):
-    """Legacy function - now just returns the original function."""
-    return func
-
-
 def _ema(values: List[float], length: int) -> List[float]:
     if length <= 1 or not values:
         return list(values)


### PR DESCRIPTION
## Summary of the issue
`src/mtdata/core/report_templates/basic.py` contained an `_unwrap_mcp_function` helper that had no callers and no remaining behavior beyond returning its input unchanged.

## Root cause
The helper was leftover compatibility code that no longer participated in report generation, but the dead definition remained in the module.

## Implemented solution
- removed the unused `_unwrap_mcp_function` helper from `src/mtdata/core/report_templates/basic.py`

## Trade-offs or limitations
This is a dead-code cleanup only; it does not change report behavior.

## Report reference
- `code-reports/to-do/dead-unwrap-function.md`