### PR TITLE
utils: share timeframe seconds map

### DIFF
--- a/src/mtdata/shared/constants.py
+++ b/src/mtdata/shared/constants.py
@@ -7,6 +7,7 @@ from ..utils.constants import (
     PRECISION_ABS_TOL,
     PRECISION_MAX_DECIMALS,
     TIME_DISPLAY_FORMAT,
+    TIMEFRAME_SECONDS,
 )
 
 # Constants (centralize defaults instead of hardcoding inline)
@@ -61,28 +62,3 @@ TIMEFRAME_MAP = {
     "MN1": mt5.TIMEFRAME_MN1,
 }
 
-# Approximate seconds per bar for timeframe window calculations
-TIMEFRAME_SECONDS = {
-    "M1": 60,
-    "M2": 120,
-    "M3": 180,
-    "M4": 240,
-    "M5": 300,
-    "M6": 360,
-    "M10": 600,
-    "M12": 720,
-    "M15": 900,
-    "M20": 1200,
-    "M30": 1800,
-    "H1": 3600,
-    "H2": 7200,
-    "H3": 10800,
-    "H4": 14400,
-    "H6": 21600,
-    "H8": 28800,
-    "H12": 43200,
-    "D1": 86400,
-    "W1": 604800,
-    # For months, use a rough average of 30 days
-    "MN1": 2592000,
-}

--- a/src/mtdata/utils/constants.py
+++ b/src/mtdata/utils/constants.py
@@ -13,3 +13,29 @@ DISPLAY_MAX_DECIMALS = 8     # default display precision for numeric outputs
 
 # Normalized datetime display format (UTC/local)
 TIME_DISPLAY_FORMAT = "%Y-%m-%d %H:%M"
+
+# Approximate seconds per bar for each timeframe (no MT5 dependency)
+TIMEFRAME_SECONDS = {
+    "M1": 60,
+    "M2": 120,
+    "M3": 180,
+    "M4": 240,
+    "M5": 300,
+    "M6": 360,
+    "M10": 600,
+    "M12": 720,
+    "M15": 900,
+    "M20": 1200,
+    "M30": 1800,
+    "H1": 3600,
+    "H2": 7200,
+    "H3": 10800,
+    "H4": 14400,
+    "H6": 21600,
+    "H8": 28800,
+    "H12": 43200,
+    "D1": 86400,
+    "W1": 604800,
+    # For months, use a rough average of 30 days
+    "MN1": 2592000,
+}

--- a/src/mtdata/utils/support_resistance.py
+++ b/src/mtdata/utils/support_resistance.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 
-from ..shared.constants import TIMEFRAME_SECONDS as _TIMEFRAME_SECONDS
+from ..utils.constants import TIMEFRAME_SECONDS as _TIMEFRAME_SECONDS
 
 _METHOD_NAME = "weighted_retests"
 _DEFAULT_REACTION_BARS = 6

--- a/src/mtdata/utils/support_resistance.py
+++ b/src/mtdata/utils/support_resistance.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 
+from ..shared.constants import TIMEFRAME_SECONDS as _TIMEFRAME_SECONDS
+
 _METHOD_NAME = "weighted_retests"
 _DEFAULT_REACTION_BARS = 6
 _DEFAULT_ADX_PERIOD = 14
@@ -37,19 +39,6 @@ _TIMEFRAME_WEIGHTS = {
     "H4": 1.15,
     "D1": 1.3,
 }
-_TIMEFRAME_SECONDS = {
-    "M1": 60,
-    "M5": 300,
-    "M15": 900,
-    "M30": 1800,
-    "H1": 3600,
-    "H4": 14400,
-    "D1": 86400,
-    "W1": 604800,
-    "MN1": 2592000,
-}
-
-
 def get_auto_support_resistance_timeframes() -> tuple[str, ...]:
     return _AUTO_TIMEFRAMES
 


### PR DESCRIPTION
## Summary of the issue
`src/mtdata/utils/support_resistance.py` carried its own copy of timeframe-second values even though a shared constants module already defined the canonical map.

## Root cause
The support/resistance utility duplicated a subset of `TIMEFRAME_SECONDS` instead of importing the shared constant, which created drift risk if one copy changed without the other. An initial fix importing from `mtdata.shared.constants` resolved the duplication but introduced an unintended MT5 eager-import side effect, since `shared.constants` builds `TIMEFRAME_MAP` using `mt5.TIMEFRAME_*` attributes at module load time.

## Implemented solution
- Moved the `TIMEFRAME_SECONDS` dict to `mtdata.utils.constants`, a lightweight module with no external dependencies, keeping it usable in offline/CI contexts without MetaTrader5 installed.
- Re-exported `TIMEFRAME_SECONDS` from `mtdata.shared.constants` for full backward compatibility with all existing callers.
- Updated `support_resistance.py` to import `TIMEFRAME_SECONDS` directly from `mtdata.utils.constants`, eliminating any MT5 dependency from that import path.

## Trade-offs or limitations
This is a straight deduplication change; behavior is unchanged. All modules that previously imported `TIMEFRAME_SECONDS` from `mtdata.shared.constants` continue to work unmodified.

## Report reference
- `code-reports/to-do/duplicate-timeframe-constants.md`