### PR TITLE
core: share pydantic field extraction

### DIFF
--- a/src/mtdata/core/_mcp_tools.py
+++ b/src/mtdata/core/_mcp_tools.py
@@ -180,6 +180,18 @@ def _coerce_float(value: Any, *, allow_none: bool, name: str) -> Any:
     raise ValueError(f"Invalid value for '{name}': expected number, got {value!r}")
 
 
+def _get_pydantic_model_fields(model_type: type[BaseModel]) -> tuple[Dict[str, Any], bool]:
+    model_fields = getattr(model_type, "model_fields", None)
+    if isinstance(model_fields, dict):
+        return model_fields, True
+
+    legacy_fields = getattr(model_type, "__fields__", None)
+    if isinstance(legacy_fields, dict):
+        return legacy_fields, False
+
+    return {}, False
+
+
 def _coerce_kwargs_for_callable(func: Any, kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """Coerce common scalar string inputs (from MCP clients) based on annotations."""
     try:
@@ -194,12 +206,8 @@ def _coerce_kwargs_for_callable(func: Any, kwargs: Dict[str, Any]) -> Dict[str, 
         if not (isinstance(base_ann, type) and issubclass(base_ann, BaseModel)):
             continue
         try:
-            model_fields = getattr(base_ann, "model_fields", None)
-            if isinstance(model_fields, dict):
-                field_names = set(model_fields.keys())
-            else:
-                legacy_fields = getattr(base_ann, "__fields__", None)
-                field_names = set(legacy_fields.keys()) if isinstance(legacy_fields, dict) else set()
+            model_fields, _ = _get_pydantic_model_fields(base_ann)
+            field_names = set(model_fields.keys())
         except Exception:
             field_names = set()
         if not field_names:
@@ -258,8 +266,8 @@ def _request_model_signature_fields(func: Any) -> List[inspect.Parameter]:
     if not (isinstance(base_ann, type) and issubclass(base_ann, BaseModel)):
         return []
 
-    model_fields = getattr(base_ann, "model_fields", None)
-    if isinstance(model_fields, dict):
+    model_fields, modern_fields = _get_pydantic_model_fields(base_ann)
+    if modern_fields:
         flattened: List[inspect.Parameter] = []
         for field_name, field in model_fields.items():
             annotation = inspect._empty
@@ -283,10 +291,9 @@ def _request_model_signature_fields(func: Any) -> List[inspect.Parameter]:
             )
         return flattened
 
-    legacy_fields = getattr(base_ann, "__fields__", None)
-    if isinstance(legacy_fields, dict):
+    if model_fields:
         flattened = []
-        for field_name, field in legacy_fields.items():
+        for field_name, field in model_fields.items():
             annotation = getattr(field, "outer_type_", getattr(field, "type_", inspect._empty))
             is_required = bool(getattr(field, "required", False))
             default = inspect._empty if is_required else _signature_default_for_model_field(field)

--- a/src/mtdata/core/cli/api.py
+++ b/src/mtdata/core/cli/api.py
@@ -22,7 +22,7 @@ from ...bootstrap.tools import bootstrap_tools
 from ...forecast.requests import ForecastGenerateRequest
 from ...utils.minimal_output import format_result_minimal as _shared_minimal
 from .._mcp_instance import mcp
-from .._mcp_tools import get_tool_registry as get_registered_tools
+from .._mcp_tools import _get_pydantic_model_fields, get_tool_registry as get_registered_tools
 from ..cli_formatting import (
     CLI_FORMAT_JSON,
     CLI_FORMAT_TOON,
@@ -179,8 +179,8 @@ def _is_pydantic_model_type(value: Any) -> bool:
 
 
 def _iter_request_model_params(model_type: type[BaseModel]) -> List[Dict[str, Any]]:
-    fields = getattr(model_type, "model_fields", None)
-    if isinstance(fields, dict):
+    fields, modern_fields = _get_pydantic_model_fields(model_type)
+    if modern_fields:
         params: List[Dict[str, Any]] = []
         for name, field in fields.items():
             required = bool(field.is_required()) if callable(getattr(field, "is_required", None)) else False
@@ -197,8 +197,7 @@ def _iter_request_model_params(model_type: type[BaseModel]) -> List[Dict[str, An
             )
         return params
 
-    legacy_fields = getattr(model_type, "__fields__", None)
-    if isinstance(legacy_fields, dict):
+    if fields:
         return [
             {
                 "name": name,
@@ -206,7 +205,7 @@ def _iter_request_model_params(model_type: type[BaseModel]) -> List[Dict[str, An
                 "default": None if getattr(field, "required", False) else getattr(field, "default", None),
                 "type": getattr(field, "outer_type_", Any) or Any,
             }
-            for name, field in legacy_fields.items()
+            for name, field in fields.items()
         ]
 
     return []

--- a/src/mtdata/core/tool_calling.py
+++ b/src/mtdata/core/tool_calling.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from ._mcp_tools import _get_pydantic_model_fields
+
 
 def unwrap_tool_callable(func: Any) -> Any:
     raw = getattr(func, "__wrapped__", None)
@@ -55,12 +57,8 @@ def _coerce_tool_kwargs(target: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
                 and isinstance(request_type, type)
                 and issubclass(request_type, BaseModel)
             ):
-                model_fields = getattr(request_type, "model_fields", None)
-                if isinstance(model_fields, dict):
-                    field_names = set(model_fields.keys())
-                else:
-                    legacy_fields = getattr(request_type, "__fields__", None)
-                    field_names = set(legacy_fields.keys()) if isinstance(legacy_fields, dict) else set()
+                model_fields, _ = _get_pydantic_model_fields(request_type)
+                field_names = set(model_fields.keys())
                 payload = {key: coerced.pop(key) for key in list(coerced.keys()) if key in field_names}
                 if payload:
                     model_validate = getattr(request_type, "model_validate", None)

--- a/tests/core/test_pydantic_field_extraction_business_logic.py
+++ b/tests/core/test_pydantic_field_extraction_business_logic.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from mtdata.core._mcp_tools import _get_pydantic_model_fields
+
+
+class _RequestModel(BaseModel):
+    symbol: str
+    limit: int = 25
+
+
+def test_get_pydantic_model_fields_reads_model_fields() -> None:
+    fields, modern = _get_pydantic_model_fields(_RequestModel)
+
+    assert modern is True
+    assert set(fields) == {"symbol", "limit"}
+
+
+class _LegacyField:
+    required = False
+    default = 25
+    outer_type_ = int
+
+
+class _LegacyRequestModel:
+    __fields__ = {"limit": _LegacyField()}
+
+
+def test_get_pydantic_model_fields_falls_back_to_legacy_fields() -> None:
+    fields, modern = _get_pydantic_model_fields(_LegacyRequestModel)
+
+    assert modern is False
+    assert set(fields) == {"limit"}


### PR DESCRIPTION
## Summary of the issue
The same Pydantic field-discovery compatibility branch was duplicated across MCP request coercion, synchronous tool calling, and CLI request-model flattening.

## Root cause
Each caller reimplemented the same `model_fields` / `__fields__` lookup logic instead of sharing one internal helper, so the compatibility behavior could drift over time.

## Implemented solution
- added `_get_pydantic_model_fields()` in `src/mtdata/core/_mcp_tools.py`
- updated `_coerce_kwargs_for_callable()`, `_request_model_signature_fields()`, `call_tool_sync_raw()` request-model coercion, and CLI request-model flattening to reuse that helper
- added a focused helper test alongside the existing request-model regression coverage

## Trade-offs or limitations
This is an internal refactor only; it keeps the current Pydantic v1/v2 compatibility behavior rather than changing any request-model semantics.

## Report reference
- `code-reports/to-do/duplicate-pydantic-field-extraction.md`