### PR TITLE
utils: share bool parsing helper

### DIFF
--- a/src/mtdata/core/_mcp_tools.py
+++ b/src/mtdata/core/_mcp_tools.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Union, cast, get_args, get_origin
 from pydantic import BaseModel
 
 from .error_envelope import build_error_payload, log_transport_exception, normalize_error_payload
-from ..utils.utils import _coerce_scalar
+from ..utils.utils import _coerce_scalar, _parse_bool_like, _UNPARSED_BOOL
 
 try:
     import annotationlib
@@ -103,25 +103,10 @@ def _unwrap_optional_annotation(annotation: Any) -> tuple[Any, bool]:
 
 
 def _coerce_bool(value: Any, *, allow_none: bool, name: str) -> Any:
-    if value is None:
-        if allow_none:
-            return None
+    parsed = _parse_bool_like(value, allow_none=allow_none)
+    if parsed is _UNPARSED_BOOL:
         raise ValueError(f"Invalid value for '{name}': expected boolean, got {value!r}")
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return bool(value)
-    if isinstance(value, str):
-        s = value.strip().lower()
-        if s in ("none", "null"):
-            if allow_none:
-                return None
-            raise ValueError(f"Invalid value for '{name}': expected boolean, got {value!r}")
-        if s in ("true", "1", "yes", "y", "on"):
-            return True
-        if s in ("false", "0", "no", "n", "off"):
-            return False
-    raise ValueError(f"Invalid value for '{name}': expected boolean, got {value!r}")
+    return parsed
 
 
 def _coerce_int(value: Any, *, allow_none: bool, name: str) -> Any:

--- a/src/mtdata/core/patterns.py
+++ b/src/mtdata/core/patterns.py
@@ -652,7 +652,8 @@ def _run_classic_engine(
 def _apply_config_to_obj(cfg: Any, config: Optional[Dict[str, Any]]) -> List[str]:
     """Apply config dict values to a config object's attributes.
 
-    Returns any unknown keys that were not applied to the target object.
+    Returns keys that were not applied to the target object, including both
+    unknown keys and keys whose values were invalid or could not be coerced.
     """
 
     if not isinstance(config, dict):

--- a/src/mtdata/core/patterns.py
+++ b/src/mtdata/core/patterns.py
@@ -38,6 +38,7 @@ from .patterns_support import (
     _to_float_safe,
     _to_jsonable,
 )
+from ..utils.utils import _parse_bool_like, _UNPARSED_BOOL
 from ..utils.mt5 import _mt5_copy_rates_from
 from ..utils.utils import _format_time_minimal, to_float_np as __to_float_np
 from ..patterns.candlestick import detect_candlestick_patterns as _detect_candlestick_patterns
@@ -654,19 +655,6 @@ def _apply_config_to_obj(cfg: Any, config: Optional[Dict[str, Any]]) -> List[str
     Returns any unknown keys that were not applied to the target object.
     """
 
-    def _coerce_bool(value: Any) -> Any:
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, (int, float)):
-            return bool(value)
-        if isinstance(value, str):
-            s = value.strip().lower()
-            if s in {"true", "1", "yes", "y", "on"}:
-                return True
-            if s in {"false", "0", "no", "n", "off"}:
-                return False
-        return value
-
     if not isinstance(config, dict):
         return []
     invalid_keys: List[str] = []
@@ -686,8 +674,8 @@ def _apply_config_to_obj(cfg: Any, config: Optional[Dict[str, Any]]) -> List[str
                 else:
                     setattr(cfg, k, [v])
             elif isinstance(current, bool):
-                coerced = _coerce_bool(v)
-                if not isinstance(coerced, bool):
+                coerced = _parse_bool_like(v)
+                if coerced is _UNPARSED_BOOL:
                     invalid_keys.append(str(k))
                     continue
                 setattr(cfg, k, bool(coerced))

--- a/src/mtdata/forecast/barriers_optimization.py
+++ b/src/mtdata/forecast/barriers_optimization.py
@@ -6,7 +6,7 @@ import numpy as np
 from ..shared.schema import TimeframeLiteral, DenoiseSpec
 from ..shared.constants import TIMEFRAME_SECONDS
 from .common import fetch_history as _fetch_history, log_returns_from_prices as _log_returns_from_prices
-from ..utils.utils import parse_kv_or_json as _parse_kv_or_json
+from ..utils.utils import _parse_bool_like, _UNPARSED_BOOL, parse_kv_or_json as _parse_kv_or_json
 from ..utils.barriers import (
     get_pip_size as _get_pip_size,
     resolve_barrier_prices as _resolve_barrier_prices,
@@ -171,17 +171,10 @@ def forecast_barrier_optimize(
             output_mode = 'summary'
 
         def _coerce_bool_flag(value: Any, default: bool = False) -> bool:
-            if isinstance(value, bool):
-                return value
-            if isinstance(value, (int, float)):
-                return bool(value)
-            if isinstance(value, str):
-                v = value.strip().lower()
-                if v in {"1", "true", "yes", "y", "on"}:
-                    return True
-                if v in {"0", "false", "no", "n", "off"}:
-                    return False
-            return bool(default)
+            parsed = _parse_bool_like(value)
+            if parsed is _UNPARSED_BOOL:
+                return bool(default)
+            return bool(parsed)
 
         search_profile_requested = str(
             params_dict.get('search_profile', params_dict.get('profile', search_profile))

--- a/src/mtdata/utils/utils.py
+++ b/src/mtdata/utils/utils.py
@@ -36,6 +36,28 @@ def _coerce_scalar(s: str):
         return s
 
 
+_UNPARSED_BOOL = object()
+
+
+def _parse_bool_like(value: Any, *, allow_none: bool = False) -> Any:
+    """Parse common boolean spellings and return a sentinel when unrecognized."""
+    if value is None:
+        return None if allow_none else _UNPARSED_BOOL
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in ("none", "null"):
+            return None if allow_none else _UNPARSED_BOOL
+        if text in ("true", "1", "yes", "y", "on"):
+            return True
+        if text in ("false", "0", "no", "n", "off"):
+            return False
+    return _UNPARSED_BOOL
+
+
 def _coerce_finite_float(value: Any) -> Optional[float]:
     """Best-effort float coercion that rejects NaN and infinity."""
     try:

--- a/tests/forecast/test_forecast_barriers.py
+++ b/tests/forecast/test_forecast_barriers.py
@@ -407,6 +407,29 @@ class TestForecastBarriers(_BarrierModulePatchMixin, unittest.TestCase):
         self.assertFalse(profile.get("refine"))
         self.assertEqual(result.get("results_total"), 16)
 
+    def test_forecast_barrier_optimize_parses_bool_flags_from_params(self):
+        self._set_flat_history(1.0)
+        paths = self._sample_paths()
+        with patch(f'{_BARRIER_OPT_ROOT}._simulate_gbm_mc') as mock_sim:
+            mock_sim.return_value = {"price_paths": paths}
+            result = forecast_barrier_optimize(
+                symbol="EURUSD",
+                timeframe="H1",
+                horizon=4,
+                method="mc_gbm",
+                direction="long",
+                mode="pct",
+                fast_defaults=False,
+                params='{"fast_defaults":"yes","viable_only":"1","concise":"true"}',
+                return_grid=True,
+            )
+        self.assertTrue(result.get("success"))
+        self.assertTrue(result.get("fast_defaults"))
+        self.assertTrue(result.get("viable_only"))
+        self.assertTrue(result.get("concise"))
+        profile = result.get("compute_profile", {})
+        self.assertEqual(profile.get("n_sims"), 1200)
+
     def test_forecast_barrier_optimize_search_profile_long(self):
         self._set_flat_history(1.0)
         paths = self._sample_paths()

--- a/tests/patterns/test_pattern_detection_behaviors.py
+++ b/tests/patterns/test_pattern_detection_behaviors.py
@@ -817,6 +817,16 @@ def test_apply_config_to_obj_coerces_bool_strings():
     assert cfg.use_dtw_check is True
 
 
+def test_apply_config_to_obj_rejects_invalid_bool_strings():
+    cfg = ClassicDetectorConfig()
+    original = cfg.use_robust_fit
+
+    invalid = _apply_config_to_obj(cfg, {"use_robust_fit": "maybe"})
+
+    assert cfg.use_robust_fit is original
+    assert invalid == ["use_robust_fit"]
+
+
 def test_apply_config_to_obj_rejects_invalid_type_coercion():
     cfg = ClassicDetectorConfig()
     original = cfg.min_distance


### PR DESCRIPTION
## Summary of the issue
Boolean parsing logic was duplicated across MCP argument coercion, pattern config application, and barrier-optimization flag parsing.

## Root cause
Each caller carried its own copy of the same bool-string parsing rules, while layering different caller-specific behavior for invalid input or defaults on top.

## Implemented solution
- added shared `_parse_bool_like()` and `_UNPARSED_BOOL` in `src/mtdata/utils/utils.py`
- updated `src/mtdata/core/_mcp_tools.py` to keep raising on invalid booleans through the shared parser
- updated `src/mtdata/core/patterns.py` to keep rejecting invalid bool config values through the shared parser
- updated `src/mtdata/forecast/barriers_optimization.py` to keep default-fallback behavior through the shared parser
- added regressions covering invalid pattern-config bool strings and bool flags passed through barrier optimization params

## Trade-offs or limitations
The refactor intentionally preserves the existing caller-specific behavior differences; it only centralizes the raw boolean parsing rules.

## Report reference
- `code-reports/to-do/duplicate-coerce-bool.md`