### PR TITLE
shared: remove dead schema types

### DIFF
--- a/src/mtdata/shared/schema.py
+++ b/src/mtdata/shared/schema.py
@@ -202,9 +202,6 @@ PARAM_HINTS = {
 _TIMEFRAME_CHOICES = tuple(sorted(TIMEFRAME_MAP.keys()))
 TimeframeLiteral = Literal[_TIMEFRAME_CHOICES]  # type: ignore
 
-# Build a Literal for single OHLCV letters; the parameter will be a list of these
-OhlcvCharLiteral = Literal['O', 'H', 'L', 'C', 'V']  # type: ignore
-
 # ---- Technical Indicators (dynamic discovery and application) ----
 def _load_indicator_doc_choices(
     list_ta_indicators_docs: Optional[Any] = None,
@@ -350,19 +347,6 @@ class SimplifySpec(TypedDict, total=False):
     # Symbolic specifics
     paa: int
     znorm: bool
-
-# Volatility params (concise)
-class VolatilityParams(TypedDict, total=False):
-    # EWMA
-    halflife: Optional[float]
-    lambda_: Optional[float]  # use 'lambda_' to avoid reserved word in schema
-    lookback: int
-    # Parkinson/GK/RS
-    window: int
-    # GARCH
-    fit_bars: int
-    mean: Literal['Zero','Constant']  # type: ignore
-    dist: Literal['normal']  # type: ignore
 
 # ---- Pivot Point methods (enums) ----
 _PIVOT_METHODS = (
@@ -515,20 +499,6 @@ def complex_defs() -> Dict[str, Any]:
             "additionalProperties": False,
             "description": "Simplify/segment/encode spec for outputs.",
         },
-        "VolatilityParams": {
-            "type": "object",
-            "properties": {
-                "halflife": {"type": ["number", "null"]},
-                "lambda_": {"type": ["number", "null"], "description": "EWMA smoothing weight"},
-                "lookback": {"type": "integer"},
-                "window": {"type": "integer"},
-                "fit_bars": {"type": "integer"},
-                "mean": {"type": "string", "enum": ["Zero", "Constant"]},
-                "dist": {"type": "string", "enum": ["normal"]},
-            },
-            "additionalProperties": False,
-            "description": "Volatility estimator parameters.",
-        },
     }
 
 
@@ -604,7 +574,6 @@ _TYPED_DICT_REFS = {
     "IndicatorSpec": "#/$defs/IndicatorSpec",
     "DenoiseSpec": "#/$defs/DenoiseSpec",
     "SimplifySpec": "#/$defs/SimplifySpec",
-    "VolatilityParams": "#/$defs/VolatilityParams",
 }
 
 _ANNOTATION_VALUE_FORMAT = getattr(getattr(annotationlib, "Format", None), "VALUE", None)

--- a/tests/utils/test_indicators_pure.py
+++ b/tests/utils/test_indicators_pure.py
@@ -7,8 +7,6 @@ Covers:
   - mtdata.core.schema        (schema validation/parsing)
 """
 
-import math
-import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Literal, Union
@@ -69,7 +67,6 @@ from mtdata.core.schema import (
     _SIMPLIFY_MODES,
     _SIMPLIFY_METHODS,
     _PIVOT_METHODS,
-    VolatilityParams,
 )
 
 
@@ -874,18 +871,12 @@ class TestComplexDefs:
         assert "IndicatorSpec" in defs
         assert "DenoiseSpec" in defs
         assert "SimplifySpec" in defs
-        assert "VolatilityParams" in defs
 
     def test_indicator_spec_structure(self):
         defs = complex_defs()
         spec = defs["IndicatorSpec"]
         assert spec["type"] == "object"
         assert "name" in spec["properties"]
-
-    def test_volatility_params_schema_matches_typed_dict_keys(self):
-        defs = complex_defs()
-
-        assert set(defs["VolatilityParams"]["properties"]) == set(VolatilityParams.__annotations__)
 
 
 class TestEnsureDefs:


### PR DESCRIPTION
## Summary of the issue
`OhlcvCharLiteral` and `VolatilityParams` in `src/mtdata/shared/schema.py` were orphaned schema types with no live runtime consumers.

## Root cause
The live volatility path parses a plain params dict directly, but the old typed dict and related schema-def plumbing remained in the shared schema module and in one stale test.

## Implemented solution
- removed `OhlcvCharLiteral` and `VolatilityParams` from `src/mtdata/shared/schema.py`
- removed the unused `VolatilityParams` schema def and typed-dict ref entry
- updated the stale indicator/schema test that still imported and asserted the dead type

## Trade-offs or limitations
This is dead-code removal only; no live request schema currently depended on these definitions.

## Report reference
- `code-reports/to-do/25-dead-schema-types-ohlc-char-volatility-params.md`