### PR TITLE
shared: unify crypto symbol detection

### DIFF
--- a/src/mtdata/core/regime/crypto.py
+++ b/src/mtdata/core/regime/crypto.py
@@ -1,33 +1,13 @@
 """Crypto detection utilities for regime detection."""
 from typing import Any
 
-_CRYPTO_SYMBOL_HINTS = (
-    "BTC",
-    "ETH",
-    "XRP",
-    "LTC",
-    "BCH",
-    "DOGE",
-    "SOL",
-    "ADA",
-    "DOT",
-    "AVAX",
-    "BNB",
-    "TRX",
-    "LINK",
-    "MATIC",
-)
+from ...shared.symbols import CRYPTO_SYMBOL_HINTS as _CRYPTO_SYMBOL_HINTS
+from ...shared.symbols import is_probably_crypto_symbol
 
 
 def _is_probably_crypto_symbol(symbol: Any) -> bool:
     """Detect if symbol is likely a cryptocurrency based on common tickers."""
-    s = str(symbol or "").upper().strip()
-    if not s:
-        return False
-    normalized = "".join(ch for ch in s if ch.isalnum())
-    if not normalized:
-        return False
-    return any(token in normalized for token in _CRYPTO_SYMBOL_HINTS)
+    return is_probably_crypto_symbol(symbol)
 
 
 __all__ = ["_is_probably_crypto_symbol", "_CRYPTO_SYMBOL_HINTS"]

--- a/src/mtdata/forecast/barriers_shared.py
+++ b/src/mtdata/forecast/barriers_shared.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 from ..shared.schema import TimeframeLiteral, DenoiseSpec
 from ..shared.constants import TIMEFRAME_SECONDS
+from ..shared.symbols import is_probably_crypto_symbol
 from .common import fetch_history as _fetch_history, log_returns_from_prices as _log_returns_from_prices
 from ..utils.utils import _safe_float, parse_kv_or_json as _parse_kv_or_json
 from ..utils.barriers import (
@@ -456,12 +457,7 @@ def _build_actionability_payload(
 
 
 def _is_crypto_symbol(symbol: str) -> bool:
-    sym = str(symbol or "").upper()
-    crypto_tokens = {
-        "BTC", "ETH", "XRP", "LTC", "SOL", "ADA", "DOGE", "BNB", "DOT",
-        "AVAX", "LINK", "TRX", "MATIC", "NEAR", "ATOM", "FIL", "UNI",
-    }
-    return any(tok in sym for tok in crypto_tokens)
+    return is_probably_crypto_symbol(symbol)
 
 
 def _auto_barrier_method(

--- a/src/mtdata/patterns/common.py
+++ b/src/mtdata/patterns/common.py
@@ -4,28 +4,11 @@ from typing import Any, Optional
 import numpy as np
 import pandas as pd
 
+from ..shared.symbols import is_probably_crypto_symbol
+
 
 def _is_probably_crypto_symbol(symbol: Any) -> bool:
-    sym = str(symbol or "").upper()
-    if not sym:
-        return False
-    crypto_tokens = {
-        "BTC",
-        "ETH",
-        "XRP",
-        "SOL",
-        "DOGE",
-        "ADA",
-        "LTC",
-        "BCH",
-        "DOT",
-        "AVAX",
-        "MATIC",
-        "LINK",
-        "ATOM",
-        "UNI",
-    }
-    return any(token in sym for token in crypto_tokens)
+    return is_probably_crypto_symbol(symbol)
 
 
 @dataclass

--- a/src/mtdata/shared/symbols.py
+++ b/src/mtdata/shared/symbols.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+CRYPTO_SYMBOL_HINTS = (
+    "BTC",
+    "ETH",
+    "XRP",
+    "LTC",
+    "BCH",
+    "DOGE",
+    "SOL",
+    "ADA",
+    "DOT",
+    "AVAX",
+    "BNB",
+    "TRX",
+    "LINK",
+    "MATIC",
+    "NEAR",
+    "ATOM",
+    "FIL",
+    "UNI",
+)
+
+
+def is_probably_crypto_symbol(symbol: Any) -> bool:
+    text = str(symbol or "").upper().strip()
+    if not text:
+        return False
+    normalized = "".join(ch for ch in text if ch.isalnum())
+    if not normalized:
+        return False
+    return any(token in normalized for token in CRYPTO_SYMBOL_HINTS)

--- a/tests/shared/test_symbol_detection_business_logic.py
+++ b/tests/shared/test_symbol_detection_business_logic.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from mtdata.core.regime.crypto import _is_probably_crypto_symbol as regime_is_crypto_symbol
+from mtdata.forecast.barriers_shared import _is_crypto_symbol as barrier_is_crypto_symbol
+from mtdata.patterns.common import _is_probably_crypto_symbol as pattern_is_crypto_symbol
+from mtdata.shared.symbols import CRYPTO_SYMBOL_HINTS, is_probably_crypto_symbol
+
+
+def test_shared_crypto_symbol_hints_include_extended_tokens() -> None:
+    assert {"BNB", "TRX", "NEAR", "FIL"}.issubset(set(CRYPTO_SYMBOL_HINTS))
+
+
+def test_crypto_symbol_detection_stays_consistent_across_modules() -> None:
+    for symbol in ("BNBUSDT", "TRXUSD", "NEARUSD", "FILUSD"):
+        assert is_probably_crypto_symbol(symbol) is True
+        assert pattern_is_crypto_symbol(symbol) is True
+        assert barrier_is_crypto_symbol(symbol) is True
+        assert regime_is_crypto_symbol(symbol) is True
+
+    for symbol in ("EURUSD", "", None):
+        assert is_probably_crypto_symbol(symbol) is False
+        assert pattern_is_crypto_symbol(symbol) is False
+        assert barrier_is_crypto_symbol(symbol) is False
+        assert regime_is_crypto_symbol(symbol) is False


### PR DESCRIPTION
## Summary of the issue
Crypto symbol detection was duplicated across patterns and barrier code, and there was already a third detector in regime code with yet another token list.

## Root cause
Each area carried its own copy of the same symbol-hint logic, so token coverage drifted over time. In particular, barrier logic recognized `BNB`, `TRX`, `NEAR`, and `FIL` while pattern logic did not.

## Implemented solution
- added shared crypto symbol detection in `src/mtdata/shared/symbols.py`
- updated `src/mtdata/patterns/common.py`, `src/mtdata/forecast/barriers_shared.py`, and `src/mtdata/core/regime/crypto.py` to reuse the shared helper and token set
- added a regression covering the previously inconsistent token set across all call sites

## Trade-offs or limitations
This keeps the existing substring-based detection approach; it only unifies the implementation and token coverage.

## Report reference
- `code-reports/to-do/duplicate-crypto-symbol-detection.md`