### PR TITLE
core: share trading done retcodes

### DIFF
--- a/src/mtdata/core/trading_execution.py
+++ b/src/mtdata/core/trading_execution.py
@@ -84,6 +84,28 @@ def _unexpected_operation_error(
     return payload
 
 
+def _trade_done_codes(mt5: Any) -> set[int]:
+    return {
+        int(getattr(mt5, "TRADE_RETCODE_DONE", 10009)),
+        int(getattr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010)),
+    }
+
+
+def _retcode_is_done(mt5: Any, retcode: Any) -> bool:
+    try:
+        return int(retcode) in _trade_done_codes(mt5)
+    except Exception:
+        return False
+
+
+def _count_done_results(mt5: Any, results: List[Dict[str, Any]]) -> int:
+    success_count = 0
+    for item in results:
+        if _retcode_is_done(mt5, item.get("retcode")):
+            success_count += 1
+    return success_count
+
+
 def _modify_position(
     ticket: Union[int, str],
     stop_loss: Optional[Union[int, float]] = None,
@@ -642,10 +664,6 @@ def _close_positions(
                 attempts: List[Dict[str, Any]] = []
                 close_type_buy = getattr(mt5, "ORDER_TYPE_BUY", 0)
                 close_type_sell = getattr(mt5, "ORDER_TYPE_SELL", 1)
-                done_codes = {
-                    int(getattr(mt5, "TRADE_RETCODE_DONE", 10009)),
-                    int(getattr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010)),
-                }
                 position_side = _resolve_position_side(position, mt5)
                 if position_side is None:
                     results.append(
@@ -737,11 +755,8 @@ def _close_positions(
                                 break
                             if recovered:
                                 retcode_val = getattr(result, "retcode", None)
-                                try:
-                                    if retcode_val is not None and int(retcode_val) in done_codes:
-                                        break
-                                except Exception:
-                                    pass
+                                if _retcode_is_done(mt5, retcode_val):
+                                    break
                                 time.sleep(0.15)
                                 continue
                         attempts.append(
@@ -763,19 +778,11 @@ def _close_positions(
                             "comment": getattr(result, "comment", None),
                         }
                     )
-                    try:
-                        if retcode_val is not None and int(retcode_val) in done_codes:
-                            break
-                    except Exception:
-                        pass
+                    if _retcode_is_done(mt5, retcode_val):
+                        break
                     time.sleep(0.15)
 
-                close_ok = False
-                if result is not None:
-                    try:
-                        close_ok = int(getattr(result, "retcode", -1)) in done_codes
-                    except Exception:
-                        close_ok = False
+                close_ok = _retcode_is_done(mt5, getattr(result, "retcode", None)) if result is not None else False
 
                 if not close_ok:
                     last_error = trading_validation._safe_last_error(mt5)
@@ -866,17 +873,7 @@ def _close_positions(
             # If only one position was targeted by ticket, return single result
             if ticket is not None and len(results) == 1:
                 return results[0]
-            success_count = 0
-            done_codes = {
-                int(getattr(mt5, "TRADE_RETCODE_DONE", 10009)),
-                int(getattr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010)),
-            }
-            for item in results:
-                try:
-                    if int(item.get("retcode")) in done_codes:
-                        success_count += 1
-                except Exception:
-                    continue
+            success_count = _count_done_results(mt5, results)
             return {"closed_count": success_count, "attempted_count": len(results), "results": results}
 
         except Exception as e:
@@ -946,17 +943,7 @@ def _cancel_pending(
             # If only one order was targeted by ticket, return single result
             if ticket is not None and len(results) == 1:
                 return results[0]
-            success_count = 0
-            done_codes = {
-                int(getattr(mt5, "TRADE_RETCODE_DONE", 10009)),
-                int(getattr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010)),
-            }
-            for item in results:
-                try:
-                    if int(item.get("retcode")) in done_codes:
-                        success_count += 1
-                except Exception:
-                    continue
+            success_count = _count_done_results(mt5, results)
             return {"cancelled_count": success_count, "attempted_count": len(results), "results": results}
 
         except Exception as e:

--- a/src/mtdata/core/trading_execution.py
+++ b/src/mtdata/core/trading_execution.py
@@ -91,17 +91,24 @@ def _trade_done_codes(mt5: Any) -> set[int]:
     }
 
 
-def _retcode_is_done(mt5: Any, retcode: Any) -> bool:
+def _retcode_is_done(
+    mt5: Any,
+    retcode: Any,
+    done_codes: Optional[set[int]] = None,
+) -> bool:
     try:
-        return int(retcode) in _trade_done_codes(mt5)
+        if done_codes is None:
+            done_codes = _trade_done_codes(mt5)
+        return int(retcode) in done_codes
     except Exception:
         return False
 
 
 def _count_done_results(mt5: Any, results: List[Dict[str, Any]]) -> int:
     success_count = 0
+    done_codes = _trade_done_codes(mt5)
     for item in results:
-        if _retcode_is_done(mt5, item.get("retcode")):
+        if _retcode_is_done(mt5, item.get("retcode"), done_codes):
             success_count += 1
     return success_count
 

--- a/tests/trading/test_trading_execution.py
+++ b/tests/trading/test_trading_execution.py
@@ -801,6 +801,31 @@ def test_close_positions_preserves_existing_magic(mock_mt5):
     assert req["magic"] == 67890
 
 
+def test_close_positions_counts_done_partial_as_success(mock_mt5):
+    mock_mt5.ORDER_FILLING_IOC = 1
+    mock_mt5.ORDER_FILLING_FOK = 0
+    mock_mt5.ORDER_FILLING_RETURN = 2
+    mock_mt5.ORDER_TIME_GTC = 0
+    mock_mt5.TRADE_RETCODE_DONE_PARTIAL = 10010
+    mock_mt5.positions_get.return_value = [
+        SimpleNamespace(ticket=123, symbol="EURUSD", volume=0.1, type=0, profit=10.0, magic=67890)
+    ]
+    mock_mt5.order_send.return_value = MagicMock(
+        retcode=10010,
+        deal=123,
+        order=456,
+        volume=0.1,
+        price=1.05010,
+        bid=1.05000,
+        ask=1.05010,
+        comment="",
+    )
+
+    res = _close_positions(symbol="EURUSD")
+
+    assert res["closed_count"] == 1
+
+
 def test_cancel_pending_counts_done_partial_as_success(mock_mt5):
     mock_mt5.TRADE_ACTION_REMOVE = 8
     mock_mt5.TRADE_RETCODE_DONE_PARTIAL = 10010


### PR DESCRIPTION
## Summary of the issue
`done_codes` and the surrounding success-counting logic were duplicated multiple times inside `src/mtdata/core/trading_execution.py`.

## Root cause
Close retries, close summaries, and cancel summaries each rebuilt the same successful-retcode set instead of sharing one internal helper.

## Implemented solution
- added shared helpers for done retcodes, retcode-success checks, and result counting in `src/mtdata/core/trading_execution.py`
- reused those helpers in close retry handling and in close/cancel summary counting
- added a focused regression proving `TRADE_RETCODE_DONE_PARTIAL` counts as success in close summaries as well as cancel summaries

## Trade-offs or limitations
This keeps the existing success criteria unchanged; it only centralizes the retcode handling.

## Report reference
- `code-reports/to-do/18-duplicate-done-codes-trading-execution.md`