### PR TITLE
core: accept partial order fills

### DIFF
--- a/src/mtdata/core/trading_orders.py
+++ b/src/mtdata/core/trading_orders.py
@@ -10,7 +10,6 @@ from .trading_gateway import MT5TradingGateway, create_trading_gateway, trading_
 from .trading_positions import _resolve_open_position
 from .trading_time import ExpirationValue
 from .trading_validation import MarketOrderTypeInput, OrderTypeInput
-from ..utils.mt5 import ensure_mt5_connection_or_raise
 
 def _compact_sl_tp_levels(
     *,
@@ -90,6 +89,20 @@ def _candidate_fill_modes(mt5: Any) -> List[int]:
     return fill_modes or [1, 0, 2]
 
 
+def _trade_done_codes(mt5: Any) -> set[int]:
+    return {
+        trading_validation._safe_int_attr(mt5, "TRADE_RETCODE_DONE", 10009),
+        trading_validation._safe_int_attr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010),
+    }
+
+
+def _retcode_is_done(mt5: Any, retcode: Any) -> bool:
+    try:
+        return int(retcode) in _trade_done_codes(mt5)
+    except Exception:
+        return False
+
+
 def _send_order_with_fill_mode_retry(
     mt5: Any,
     request: Dict[str, Any],
@@ -99,7 +112,6 @@ def _send_order_with_fill_mode_retry(
     last_comment_fallback = None
     last_error = None
     last_request = dict(request)
-    done_code = trading_validation._safe_int_attr(mt5, "TRADE_RETCODE_DONE", 10009)
     for fill_mode in _candidate_fill_modes(mt5):
         attempt_request = dict(request)
         attempt_request["type_filling"] = int(fill_mode)
@@ -125,7 +137,7 @@ def _send_order_with_fill_mode_retry(
             else attempt_request
         )
         try:
-            if result is not None and int(getattr(result, "retcode", -1)) == int(done_code):
+            if result is not None and _retcode_is_done(mt5, getattr(result, "retcode", -1)):
                 return result, comment_fallback, last_error, attempts, last_request
         except Exception:
             pass
@@ -282,7 +294,7 @@ def _place_market_order(
                     "comment_fallback": comment_fallback,
                     "fill_mode_attempts": fill_mode_attempts,
                 }
-            if getattr(result, "retcode", None) != mt5.TRADE_RETCODE_DONE:
+            if not _retcode_is_done(mt5, getattr(result, "retcode", None)):
                 error_message = "Failed to send order"
                 invalid_comment = (
                     comment_fallback.get("invalid_comment_error")
@@ -774,7 +786,7 @@ def _place_pending_order(
                     "fill_mode_attempts": fill_mode_attempts,
                 }
 
-            if getattr(result, "retcode", None) != mt5.TRADE_RETCODE_DONE:
+            if not _retcode_is_done(mt5, getattr(result, "retcode", None)):
                 error_message = "Failed to send pending order"
                 invalid_comment = (
                     comment_fallback.get("invalid_comment_error")

--- a/tests/trading/test_trading_execution.py
+++ b/tests/trading/test_trading_execution.py
@@ -582,6 +582,37 @@ def test_place_market_order_retries_fill_modes_when_first_mode_fails(mock_mt5):
     assert second_req["type_filling"] == mock_mt5.ORDER_FILLING_FOK
 
 
+def test_place_market_order_accepts_done_partial_without_retry(mock_mt5):
+    mock_mt5.ORDER_FILLING_IOC = 1
+    mock_mt5.ORDER_FILLING_FOK = 0
+    mock_mt5.ORDER_FILLING_RETURN = 2
+    mock_mt5.ORDER_TIME_GTC = 0
+    mock_mt5.TRADE_RETCODE_DONE_PARTIAL = 10010
+    mock_mt5.order_send.return_value = MagicMock(
+        retcode=10010,
+        deal=123,
+        order=456,
+        volume=0.05,
+        price=1.05010,
+        bid=1.05000,
+        ask=1.05010,
+        comment="partial fill",
+        request_id=702,
+    )
+
+    res = _place_market_order(
+        symbol="EURUSD",
+        volume=0.1,
+        order_type="BUY",
+    )
+
+    assert "error" not in res
+    assert res["retcode"] == 10010
+    assert len(res["fill_mode_attempts"]) == 1
+    assert res["type_filling_used"] == mock_mt5.ORDER_FILLING_IOC
+    assert mock_mt5.order_send.call_count == 1
+
+
 def test_place_pending_order_retries_fill_modes_when_first_mode_fails(mock_mt5):
     mock_mt5.ORDER_FILLING_IOC = 1
     mock_mt5.ORDER_FILLING_FOK = 0
@@ -626,6 +657,39 @@ def test_place_pending_order_retries_fill_modes_when_first_mode_fails(mock_mt5):
     second_req = mock_mt5.order_send.call_args_list[1].args[0]
     assert first_req["type_filling"] == mock_mt5.ORDER_FILLING_IOC
     assert second_req["type_filling"] == mock_mt5.ORDER_FILLING_FOK
+
+
+def test_place_pending_order_accepts_done_partial_without_retry(mock_mt5):
+    mock_mt5.ORDER_FILLING_IOC = 1
+    mock_mt5.ORDER_FILLING_FOK = 0
+    mock_mt5.ORDER_FILLING_RETURN = 2
+    mock_mt5.ORDER_TIME_GTC = 0
+    mock_mt5.TRADE_RETCODE_DONE_PARTIAL = 10010
+    mock_mt5.order_send.return_value = MagicMock(
+        retcode=10010,
+        deal=0,
+        order=456,
+        volume=0.05,
+        price=1.04000,
+        bid=1.05000,
+        ask=1.05010,
+        comment="partial fill",
+        request_id=802,
+    )
+
+    res = _place_pending_order(
+        symbol="EURUSD",
+        volume=0.1,
+        order_type="BUY_LIMIT",
+        price=1.04000,
+    )
+
+    assert "error" not in res
+    assert res["success"] is True
+    assert res["retcode"] == 10010
+    assert len(res["fill_mode_attempts"]) == 1
+    assert res["type_filling_used"] == mock_mt5.ORDER_FILLING_IOC
+    assert mock_mt5.order_send.call_count == 1
 
 
 def test_place_market_order_preserves_existing_position_magic_on_sltp_follow_up(mock_mt5):


### PR DESCRIPTION
## Summary
- `_send_order_with_fill_mode_retry()` treated only `TRADE_RETCODE_DONE` as success
- both market and pending order flows also rejected `DONE_PARTIAL` after the retry helper returned
- accept partial fills as successful MT5 order outcomes instead of retrying or surfacing them as errors

## Root cause
The trading order path had three done-only checks in `trading_orders.py`: one inside the fill-mode retry loop and one final success check in each of the market and pending order handlers. A partial fill could therefore either fall through to another retry attempt or be returned as a failure even after the retry loop stopped.

## Implemented solution
- added internal helpers in `trading_orders.py` to treat both `TRADE_RETCODE_DONE` and `TRADE_RETCODE_DONE_PARTIAL` as successful outcomes
- reused those helpers in the fill-mode retry loop and in the final market/pending order success checks
- added regressions proving market and pending orders accept `DONE_PARTIAL` without retrying extra fill modes

## Trade-offs / limitations
- this change is intentionally scoped to order placement; other trading surfaces still need their own explicit success handling when MT5 retcodes differ

## Report
- Resolves `code-reports/to-do/trading-orders-done-partial-not-recognized.md`