### PR TITLE
core: use gateway position types

### DIFF
--- a/src/mtdata/core/trading_use_cases.py
+++ b/src/mtdata/core/trading_use_cases.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from ..utils.barriers import normalize_trade_direction
 from ..utils.mt5 import MT5ConnectionError
+from . import trading_validation
 from .execution_logging import (
     infer_result_success,
     log_operation_finish,
@@ -1071,6 +1072,16 @@ def run_trade_risk_analyze(
             if positions is None:
                 positions = []
 
+            position_type_buy = trading_validation._safe_int_attr(
+                gateway,
+                "POSITION_TYPE_BUY",
+                trading_validation._safe_int_attr(gateway, "ORDER_TYPE_BUY", 0),
+            )
+            position_type_sell = trading_validation._safe_int_attr(
+                gateway,
+                "POSITION_TYPE_SELL",
+                trading_validation._safe_int_attr(gateway, "ORDER_TYPE_SELL", 1),
+            )
             position_risks: List[Dict[str, Any]] = []
             risk_calculation_failures: List[Dict[str, Any]] = []
             total_risk_currency = 0.0
@@ -1114,11 +1125,13 @@ def run_trade_risk_analyze(
                     reward_currency = None
                     rr_ratio = None
                     risk_status = "undefined"
+                    position_type = trading_validation._safe_int_attr(pos, "type", position_type_sell)
+                    is_buy_position = int(position_type) == int(position_type_buy)
 
                     if sl_price and tick_size > 0 and tick_value_valid:
                         risk_ticks = (
                             (entry_price - sl_price) / tick_size
-                            if pos.type == 0
+                            if is_buy_position
                             else (sl_price - entry_price) / tick_size
                         )
                         risk_currency = abs(risk_ticks * tick_value * volume)
@@ -1129,7 +1142,7 @@ def run_trade_risk_analyze(
                         if tp_price:
                             reward_ticks = (
                                 (tp_price - entry_price) / tick_size
-                                if pos.type == 0
+                                if is_buy_position
                                 else (entry_price - tp_price) / tick_size
                             )
                             reward_currency = abs(reward_ticks * tick_value * volume)
@@ -1153,7 +1166,7 @@ def run_trade_risk_analyze(
                         {
                             "ticket": pos.ticket,
                             "symbol": pos.symbol,
-                            "type": "BUY" if pos.type == 0 else "SELL",
+                            "type": "BUY" if is_buy_position else "SELL",
                             "volume": volume,
                             "entry": entry_price,
                             "sl": sl_price,

--- a/tests/trading/test_trading_risk_business_logic.py
+++ b/tests/trading/test_trading_risk_business_logic.py
@@ -225,6 +225,35 @@ def test_trade_risk_analyze_logs_finish_event(caplog) -> None:
     )
 
 
+def test_run_trade_risk_analyze_uses_gateway_position_type_constants() -> None:
+    gateway = SimpleNamespace(
+        POSITION_TYPE_BUY=7,
+        POSITION_TYPE_SELL=9,
+        ensure_connection=lambda: None,
+        account_info=lambda: SimpleNamespace(equity=1000.0, currency="USD"),
+        positions_get=lambda symbol=None: [
+            SimpleNamespace(
+                ticket=11,
+                symbol="EURUSD",
+                type=7,
+                volume=0.1,
+                price_open=100.0,
+                sl=90.0,
+                tp=120.0,
+            )
+        ],
+        symbol_info=lambda symbol: _make_symbol_info(),
+    )
+
+    out = run_trade_risk_analyze(
+        TradeRiskAnalyzeRequest(symbol="EURUSD"),
+        gateway=gateway,
+    )
+
+    assert out["success"] is True
+    assert out["positions"][0]["type"] == "BUY"
+
+
 def test_trade_risk_analyze_reports_calculation_failures() -> None:
     mt5 = MagicMock()
     prev = sys.modules.get("MetaTrader5")


### PR DESCRIPTION
## Summary
- `run_trade_risk_analyze()` was hardcoding BUY positions as `type == 0`
- gateways or adapters can expose different numeric enums for `POSITION_TYPE_BUY` / `POSITION_TYPE_SELL`
- use the gateway-provided constants when classifying positions for risk output

## Root cause
The position risk loop in `trading_use_cases.py` compared `pos.type == 0` directly in three places. That bypassed the gateway abstraction and could mislabel BUY positions whenever the adapter used non-default enum values.

## Implemented solution
- derived BUY/SELL position type values from the gateway using MT5-compatible fallbacks
- reused the resolved constants for risk/reward direction checks and for the emitted position type label
- added a regression proving risk analysis reports BUY correctly when the gateway exposes non-zero position type values

## Trade-offs / limitations
- unknown position type values still fall back to SELL behavior to preserve the existing output shape for unmapped adapters

## Report
- Resolves `code-reports/to-do/19-hardcoded-position-type-constants-risk.md`