### PR TITLE
utils: preserve candlestick indicator names

### DIFF
--- a/src/mtdata/utils/indicators.py
+++ b/src/mtdata/utils/indicators.py
@@ -247,8 +247,15 @@ def _parse_ti_specs(spec: str) -> List[Tuple[str, List[int | float], Dict[str, i
                         args.append(num)
         # Flex: detect trailing number in name (EMA21 -> length=21)
         import re
+        normalized_name = _normalize_ta_indicator_name(name.strip())
         m = re.search(r"(.*?)[_\-]?([0-9]{1,3})$", name)
-        if m and str(m.group(1) or "").strip() and not args and 'length' not in kwargs:
+        if (
+            m
+            and str(m.group(1) or "").strip()
+            and not normalized_name.startswith("cdl_")
+            and not args
+            and 'length' not in kwargs
+        ):
             try:
                 kwargs['length'] = int(m.group(2))
                 name = m.group(1)

--- a/tests/utils/test_indicators_pure.py
+++ b/tests/utils/test_indicators_pure.py
@@ -7,8 +7,6 @@ Covers:
   - mtdata.core.schema        (schema validation/parsing)
 """
 
-import math
-import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Literal, Union
@@ -216,6 +214,16 @@ class TestParseTiSpecs:
         name, args, kwargs = specs[0]
         assert name == "ema"
         assert kwargs.get("length") == 21
+
+    def test_cdl_name_with_trailing_digits_is_not_rewritten(self):
+        specs = _parse_ti_specs("CDL_FAKE12")
+        name, args, kwargs = specs[0]
+        assert name == "cdl_fake12"
+        assert args == []
+        assert kwargs == {}
+
+    def test_cdl_name_with_trailing_digits_is_reported_as_unknown(self):
+        assert _find_unknown_ta_indicators("CDL_FAKE12") == ["cdl_fake12"]
 
     def test_nested_parens_not_split(self):
         specs = _parse_ti_specs("rsi(14),macd(12,26,9)")


### PR DESCRIPTION
## Summary
- the trailing-number heuristic in `_parse_ti_specs()` rewrote every indicator name ending in digits into a `length=` argument
- that also affected `cdl_*` candlestick names, which should stay literal and be rejected as unknown if they do not exist
- keep candlestick names intact so bogus `cdl_*NN` inputs do not silently turn into another indicator call

## Root cause
`utils/indicators.py` applied the trailing-digit regex before normalizing the indicator name and without excluding candlestick namespaces. As a result, names like `cdl_fake12` were rewritten to `cdl_fake` with `length=12`, and later failure handling could hide the mistake instead of reporting the original unknown indicator cleanly.

## Implemented solution
- skipped the trailing-number-to-length rewrite for normalized indicator names beginning with `cdl_`
- added parser coverage proving `CDL_FAKE12` stays `cdl_fake12` without injected kwargs
- added an unknown-indicator regression proving the original candlestick name is reported back cleanly

## Trade-offs / limitations
- the trailing-digit shorthand still applies to non-candlestick indicators like `EMA21`, preserving the existing convenience behavior there

## Report
- Resolves `code-reports/to-do/indicators-trailing-regex-candlestick.md`