### PR TITLE
core: validate HMM state count

### DIFF
--- a/src/mtdata/core/regime/api.py
+++ b/src/mtdata/core/regime/api.py
@@ -13,12 +13,18 @@ from .. import features as _features_module
 from ...forecast.common import fetch_history as _fetch_history
 from ...utils.utils import _format_time_minimal
 from ...utils.denoise import _resolve_denoise_base_col
-from ...utils.mt5 import ensure_mt5_connection_or_raise
+from ...utils.mt5 import MT5ConnectionError, ensure_mt5_connection_or_raise
 
 # Import from package submodules directly to avoid circular imports
 from .smoothing import (
+    _count_state_transitions,
+    _state_runs,
     _smooth_short_state_runs,
     _normalize_state_probability_matrix,
+)
+from .crypto import (
+    _is_probably_crypto_symbol,
+    _CRYPTO_SYMBOL_HINTS,
 )
 from .payload import (
     _consolidate_payload,
@@ -426,16 +432,16 @@ def regime_detect(
 
         elif method == 'hmm':  # 'hmm' (mixture/HMM-lite)
             try:
-                from ...forecast.monte_carlo import fit_gaussian_mixture_1d
-            except Exception as ex:
-                return _finish({"error": f"HMM-lite import error: {ex}"})
-            fit_gaussian_mixture_1d = globals().get("fit_gaussian_mixture_1d", fit_gaussian_mixture_1d)
-            try:
                 n_states = int(p.get('n_states', 2))
             except Exception:
                 return _finish({"error": "n_states must be an integer >= 2 for hmm."})
             if n_states < 2:
                 return _finish({"error": "n_states must be >= 2 for hmm."})
+            try:
+                from ...forecast.monte_carlo import fit_gaussian_mixture_1d
+            except Exception as ex:
+                return _finish({"error": f"HMM-lite import error: {ex}"})
+            fit_gaussian_mixture_1d = globals().get("fit_gaussian_mixture_1d", fit_gaussian_mixture_1d)
             w, mu, sigma, gamma, _ = fit_gaussian_mixture_1d(x, n_states=n_states)
             gamma_matrix = _normalize_state_probability_matrix(
                 gamma,

--- a/src/mtdata/core/regime/api.py
+++ b/src/mtdata/core/regime/api.py
@@ -1,5 +1,5 @@
 """Regime detection implementation."""
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional
 import logging
 import time
 import numpy as np
@@ -8,24 +8,17 @@ from .._mcp_instance import mcp
 from ..execution_logging import infer_result_success, log_operation_finish, log_operation_start
 from ..mt5_gateway import get_mt5_gateway, mt5_connection_error
 from ..schema import TimeframeLiteral, DenoiseSpec
-from ..constants import TIMEFRAME_SECONDS
 from ..features import extract_rolling_features
 from .. import features as _features_module
 from ...forecast.common import fetch_history as _fetch_history
 from ...utils.utils import _format_time_minimal
 from ...utils.denoise import _resolve_denoise_base_col
-from ...utils.mt5 import MT5ConnectionError, ensure_mt5_connection_or_raise
+from ...utils.mt5 import ensure_mt5_connection_or_raise
 
 # Import from package submodules directly to avoid circular imports
 from .smoothing import (
-    _count_state_transitions,
-    _state_runs,
     _smooth_short_state_runs,
     _normalize_state_probability_matrix,
-)
-from .crypto import (
-    _is_probably_crypto_symbol,
-    _CRYPTO_SYMBOL_HINTS,
 )
 from .payload import (
     _consolidate_payload,
@@ -437,8 +430,13 @@ def regime_detect(
             except Exception as ex:
                 return _finish({"error": f"HMM-lite import error: {ex}"})
             fit_gaussian_mixture_1d = globals().get("fit_gaussian_mixture_1d", fit_gaussian_mixture_1d)
-            n_states = int(p.get('n_states', 2))
-            w, mu, sigma, gamma, _ = fit_gaussian_mixture_1d(x, n_states=max(2, n_states))
+            try:
+                n_states = int(p.get('n_states', 2))
+            except Exception:
+                return _finish({"error": "n_states must be an integer >= 2 for hmm."})
+            if n_states < 2:
+                return _finish({"error": "n_states must be >= 2 for hmm."})
+            w, mu, sigma, gamma, _ = fit_gaussian_mixture_1d(x, n_states=n_states)
             gamma_matrix = _normalize_state_probability_matrix(
                 gamma,
                 rows=x.size,

--- a/tests/core/test_regime_core_coverage.py
+++ b/tests/core/test_regime_core_coverage.py
@@ -734,6 +734,18 @@ class TestRegimeDetectHMM:
                       params={"n_states": 3}, output="full")
         assert isinstance(res, dict)
 
+    @patch(_FMT, side_effect=_time_fmt_stub)
+    @patch(_DENOISE, return_value="close")
+    @patch(_FETCH)
+    def test_hmm_rejects_single_state_request(self, mock_fetch, mock_denoise, mock_fmt):
+        df = _make_df(60)
+        mock_fetch.return_value = df
+        with patch("mtdata.forecast.monte_carlo.fit_gaussian_mixture_1d", create=True) as mock_fit:
+            fn = _get_regime_detect()
+            res = fn("EURUSD", limit=60, method="hmm", params={"n_states": 1}, output="full")
+        assert res == {"error": "n_states must be >= 2 for hmm."}
+        mock_fit.assert_not_called()
+
 
 class TestRegimeDetectClustering:
 


### PR DESCRIPTION
## Summary
- the HMM regime API accepted `n_states=1` even though the fitter already enforced a minimum of two states
- that let the payload claim one requested state while the model fit two, truncated the probability matrix to one column, and produced misleading reliability output
- reject invalid one-state HMM requests at the API boundary

## Root cause
`regime/api.py` parsed `n_states` directly from params, passed `max(2, n_states)` into the fitter, and then serialized probabilities using the original requested value. For `n_states=1`, the API therefore reported an impossible one-state payload for a two-state fit.

## Implemented solution
- added explicit HMM `n_states` validation so the API requires an integer >= 2
- removed the hidden `max(2, n_states)` fallback once the request is validated
- added a regression proving `n_states=1` returns a clear error and never calls the HMM fitter

## Trade-offs / limitations
- callers that were previously relying on the silent coercion to two states must now pass `n_states=2` explicitly

## Report
- Resolves `code-reports/to-do/03-hmm-reliability-edge-case.md`