### PR TITLE
forecast: widen power analysis type

### DIFF
--- a/src/mtdata/forecast/barrier_stats.py
+++ b/src/mtdata/forecast/barrier_stats.py
@@ -15,6 +15,8 @@ import math
 import numpy as np
 from scipy import stats as scipy_stats
 
+BarrierPowerAnalysisValue = Union[float, int, str]
+
 
 def minimum_simulations_for_ci_width(
     target_width: float = 0.05,
@@ -589,7 +591,7 @@ def statistical_power_analysis(
     effect_size: float,
     n_sims: int,
     alpha: float = 0.05,
-) -> Dict[str, float]:
+) -> Dict[str, BarrierPowerAnalysisValue]:
     """Calculate statistical power to detect an effect in barrier probabilities.
     
     Args:

--- a/tests/forecast/test_barrier_stats.py
+++ b/tests/forecast/test_barrier_stats.py
@@ -328,6 +328,15 @@ class TestBarrierStats(unittest.TestCase):
         self.assertLess(result['power'], 0.5)
         self.assertIn('min_n_for_80_power', result)
         self.assertGreater(result['min_n_for_80_power'], 100)
+
+    def test_statistical_power_analysis_invalid_base_prob_returns_error(self):
+        result = statistical_power_analysis(
+            base_prob=1.0,
+            effect_size=0.05,
+            n_sims=100,
+        )
+
+        self.assertEqual(result, {"error": "base_prob must be in (0, 1)"})
     
     def test_ensemble_ci_from_multiple_methods(self):
         """Test ensemble confidence interval combination."""


### PR DESCRIPTION
## Summary
- `statistical_power_analysis()` was annotated as returning `Dict[str, float]`
- the function actually returns ints and strings as well, including error payloads like `{"error": ...}`
- widen the return annotation to match the real payload shape

## Root cause
The return annotation in `forecast/barrier_stats.py` only described the successful float-valued subset of the payload and ignored both integer fields (`n_sims`, `min_n_for_80_power`) and string fields (`error`, `interpretation`). That made the signature narrower than the function’s real contract.

## Implemented solution
- introduced a small `BarrierPowerAnalysisValue` alias covering `float | int | str`
- updated `statistical_power_analysis()` to return `Dict[str, BarrierPowerAnalysisValue]`
- added an error-path regression that asserts the string error payload for invalid `base_prob`

## Trade-offs / limitations
- this fixes the concrete mismatch in `statistical_power_analysis()` only; it does not attempt a wider typing cleanup across the rest of `barrier_stats.py`

## Report
- Resolves `code-reports/to-do/return-type-annotations-barrier-stats.md`