### PR TITLE
forecast: widen HMM simulation type

### DIFF
--- a/src/mtdata/forecast/monte_carlo.py
+++ b/src/mtdata/forecast/monte_carlo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Monte Carlo simulation utilities, including a Gaussian-HMM regime model.
 
 This module provides two primary helpers:
@@ -15,7 +13,9 @@ This module relies on numpy/pandas plus sklearn (GaussianMixture), hmmlearn
 (Gaussian HMM), and arch (bootstrap/GARCH).
 """
 
-from typing import Dict, Tuple, Optional
+from __future__ import annotations
+
+from typing import Dict, Tuple, Optional, Union
 import numpy as np
 import warnings
 from sklearn.mixture import GaussianMixture
@@ -23,6 +23,8 @@ try:
     from sklearn.exceptions import ConvergenceWarning as _SklearnConvergenceWarning
 except Exception:  # pragma: no cover - defensive fallback
     _SklearnConvergenceWarning = Warning
+
+HmmSimulationValue = Union[np.ndarray, str]
 
 
 def _load_circular_block_bootstrap():
@@ -241,7 +243,7 @@ def simulate_hmm_mc(
     n_states: int = 2,
     n_sims: int = 500,
     seed: Optional[int] = 42,
-) -> Dict[str, np.ndarray]:
+) -> Dict[str, HmmSimulationValue]:
     """Fit a regime model to log-returns and simulate future price paths.
 
     Calibration backend:

--- a/tests/forecast/test_monte_carlo_pure.py
+++ b/tests/forecast/test_monte_carlo_pure.py
@@ -1,4 +1,6 @@
 """Tests for forecast/monte_carlo.py — pure NumPy simulation functions."""
+from typing import get_args, get_origin, get_type_hints
+
 import numpy as np
 import pytest
 import warnings
@@ -216,6 +218,17 @@ class TestSimulateHmmMc:
     def _prices(self, n=200, seed=42):
         rng = np.random.RandomState(seed)
         return 100.0 * np.exp(np.cumsum(rng.normal(0, 0.01, n)))
+
+    def test_return_annotation_allows_arrays_and_model_type_string(self):
+        return_hint = get_type_hints(simulate_hmm_mc)["return"]
+        origin = get_origin(return_hint)
+        key_type, value_type = get_args(return_hint)
+        value_types = set(get_args(value_type))
+
+        assert origin is dict
+        assert key_type is str
+        assert np.ndarray in value_types
+        assert str in value_types
 
     def test_output_keys(self):
         result = simulate_hmm_mc(self._prices(), horizon=10, n_sims=30, seed=1)


### PR DESCRIPTION
## Summary
- `simulate_hmm_mc()` was annotated as returning `Dict[str, np.ndarray]`
- the function also returns `model_type`, which is a string
- widen the return type so the signature matches the real Monte Carlo payload

## Root cause
The helper in `forecast/monte_carlo.py` returns a mixed payload of arrays plus a descriptive `model_type` string, but its annotation only allowed ndarray values. That made the public contract narrower than the actual runtime behavior.

## Implemented solution
- introduced a `HmmSimulationValue` alias covering `np.ndarray | str`
- updated `simulate_hmm_mc()` to return `Dict[str, HmmSimulationValue]`
- added a focused type-hint regression that asserts the return annotation resolves to both ndarray and string values
- fixed the module header ordering in `monte_carlo.py` while touching the file so lint stays clean

## Trade-offs / limitations
- this change only widens the concrete `simulate_hmm_mc()` contract; it does not attempt a broader type cleanup across the Monte Carlo module

## Report
- Resolves `code-reports/to-do/type-annotation-error-simulate-hmm.md`