### PR TITLE
core: forward barrier volatility params

### DIFF
--- a/src/mtdata/core/report_templates/basic.py
+++ b/src/mtdata/core/report_templates/basic.py
@@ -889,6 +889,19 @@ def template_basic(
     rr_max_default = p.get('rr_max', 2.0)
     base_params.setdefault('rr_min', rr_min_default)
     base_params.setdefault('rr_max', rr_max_default)
+    for barrier_key in (
+        'vol_window',
+        'vol_min_mult',
+        'vol_max_mult',
+        'vol_steps',
+        'vol_sl_extra',
+        'vol_sl_multiplier',
+        'vol_sl_steps',
+        'vol_floor_pct',
+        'vol_floor_pips',
+    ):
+        if barrier_key in p:
+            base_params.setdefault(barrier_key, p.get(barrier_key))
     p['params'] = base_params
 
     mode_val = str(p.get('mode', 'pct'))

--- a/tests/core/test_report_templates_pure.py
+++ b/tests/core/test_report_templates_pure.py
@@ -928,6 +928,54 @@ class TestTemplateBasic:
     @patch(f"{_BASIC_MODULE}._get_raw_result")
     @patch(f"{_BASIC_MODULE}.now_utc_iso", return_value="2024-01-15T00:00:00Z")
     @patch(f"{_BASIC_MODULE}.parse_table_tail")
+    @patch(f"{_BASIC_MODULE}.pick_best_forecast_method", return_value=None)
+    @patch(f"{_BASIC_MODULE}.summarize_barrier_grid")
+    @patch(f"{_BASIC_MODULE}.attach_multi_timeframes")
+    def test_basic_barriers_forward_template_volatility_defaults(
+        self, mock_mtf, mock_sum_bar, mock_pick, mock_tail,
+        mock_now, mock_raw,
+    ):
+        candle_rows = _mock_candle_data()["rows"]
+        mock_tail.return_value = candle_rows[-40:]
+        mock_sum_bar.return_value = {"best": {"tp": 1.0, "sl": 0.5, "edge": 0.3}, "top": []}
+        barrier_params = []
+
+        def raw_side_effect(func, *args, **kwargs):
+            name = func.__name__ if hasattr(func, "__name__") else str(func)
+            if "candle" in name.lower() or "data_fetch" in name.lower():
+                return _mock_candle_data()
+            if "pivot" in name.lower():
+                return _mock_pivot_data()
+            if "volatility" in name.lower():
+                return _mock_vol_data()
+            if "backtest" in name.lower():
+                return {"results": {}}
+            if "forecast_generate" in name.lower() or "generate" in name.lower():
+                return _mock_forecast_data()
+            if "barrier" in name.lower():
+                barrier_params.append(dict(kwargs.get("params") or {}))
+                return _mock_barrier_data()
+            if "pattern" in name.lower():
+                return _mock_patterns_data()
+            return {"data": "ok"}
+
+        mock_raw.side_effect = raw_side_effect
+
+        from mtdata.core.report_templates.basic import template_basic
+        _ = template_basic("EURUSD", 12, None, {})
+
+        assert len(barrier_params) == 2
+        for params in barrier_params:
+            assert params["vol_window"] == 250
+            assert params["vol_min_mult"] == 0.6
+            assert params["vol_max_mult"] == 2.2
+            assert params["vol_sl_multiplier"] == 1.7
+            assert params["vol_sl_steps"] == 9
+            assert params["vol_floor_pct"] == 0.2
+
+    @patch(f"{_BASIC_MODULE}._get_raw_result")
+    @patch(f"{_BASIC_MODULE}.now_utc_iso", return_value="2024-01-15T00:00:00Z")
+    @patch(f"{_BASIC_MODULE}.parse_table_tail")
     @patch(f"{_BASIC_MODULE}.pick_best_forecast_method")
     @patch(f"{_BASIC_MODULE}.summarize_barrier_grid")
     @patch(f"{_BASIC_MODULE}.attach_multi_timeframes")


### PR DESCRIPTION
## Summary
- the basic report template sets barrier-volatility defaults at the template level
- it then rebuilds `p["params"]` and only forwards that nested dict to `forecast_barrier_optimize`
- copy the template’s volatility defaults into nested `params` so the barrier optimizer actually sees them

## Root cause
`template_basic()` set defaults like `vol_window`, `vol_min_mult`, `vol_max_mult`, `vol_sl_multiplier`, `vol_sl_steps`, and the volatility floor fields on the top-level template parameter dict. Later it reconstructed `base_params` from `p.get("params")` but only copied spread/slippage and RR defaults, so the optimizer-specific volatility defaults were dropped before the barrier calls.

## Implemented solution
- forwarded the template’s barrier-volatility keys into `base_params` using `setdefault`, preserving any explicit nested `params` overrides
- added a focused template regression that captures both barrier optimizer calls and verifies the forwarded volatility defaults are present in `params`

## Trade-offs / limitations
- this fix is scoped to the basic template; other templates still need their own explicit pass-through if they set optimizer defaults at the top level

## Report
- Resolves `code-reports/to-do/basic-template-vol-params-not-forwarded.md`