### PR TITLE
core: keep dated trades when truncating

### DIFF
--- a/src/mtdata/core/trading_use_cases.py
+++ b/src/mtdata/core/trading_use_cases.py
@@ -1769,15 +1769,11 @@ def _run_trade_get_pending_impl(
 
         limit_value = normalize_limit(request.limit)
         if limit_value and len(out_df) > limit_value:
-            out_df = (
-                out_df.sort_values(
-                    "__time_utc",
-                    kind="stable",
-                    na_position="first",
-                ).tail(limit_value)
-                if "__time_utc" in out_df.columns
-                else out_df.head(limit_value)
-            )
+            out_df = out_df.sort_values(
+                "__time_utc",
+                kind="stable",
+                na_position="first",
+            ).tail(limit_value)
         if "__time_utc" in out_df.columns:
             out_df = out_df.drop(columns=["__time_utc"])
         return out_df.to_dict(orient="records")

--- a/src/mtdata/core/trading_use_cases.py
+++ b/src/mtdata/core/trading_use_cases.py
@@ -1619,7 +1619,11 @@ def _run_trade_get_open_impl(
 
         limit_value = normalize_limit(request.limit)
         if limit_value and len(out_df) > limit_value:
-            out_df = out_df.sort_values("__time_utc").tail(limit_value)
+            out_df = out_df.sort_values(
+                "__time_utc",
+                kind="stable",
+                na_position="first",
+            ).tail(limit_value)
         if "__time_utc" in out_df.columns:
             out_df = out_df.drop(columns=["__time_utc"])
         return out_df.to_dict(orient="records")
@@ -1766,7 +1770,11 @@ def _run_trade_get_pending_impl(
         limit_value = normalize_limit(request.limit)
         if limit_value and len(out_df) > limit_value:
             out_df = (
-                out_df.sort_values("__time_utc").tail(limit_value)
+                out_df.sort_values(
+                    "__time_utc",
+                    kind="stable",
+                    na_position="first",
+                ).tail(limit_value)
                 if "__time_utc" in out_df.columns
                 else out_df.head(limit_value)
             )

--- a/tests/trading/test_trading_account_business_logic.py
+++ b/tests/trading/test_trading_account_business_logic.py
@@ -261,6 +261,112 @@ def test_run_trade_get_pending_logs_finish_event(caplog) -> None:
     )
 
 
+def test_run_trade_get_open_limit_prefers_latest_valid_timestamps() -> None:
+    Position = namedtuple(
+        "Position",
+        [
+            "ticket",
+            "symbol",
+            "time_update",
+            "type",
+            "volume",
+            "price_open",
+            "sl",
+            "tp",
+            "price_current",
+            "swap",
+            "profit",
+            "comment",
+            "magic",
+        ],
+    )
+    rows = [
+        Position(1, "EURUSD", 100, 0, 0.1, 1.1, 1.0, 1.2, 1.15, 0.0, 1.0, "old", 7),
+        Position(2, "EURUSD", None, 0, 0.1, 1.1, 1.0, 1.2, 1.15, 0.0, 2.0, "missing", 7),
+        Position(3, "EURUSD", 200, 0, 0.1, 1.1, 1.0, 1.2, 1.15, 0.0, 3.0, "mid", 7),
+        Position(4, "EURUSD", 300, 0, 0.1, 1.1, 1.0, 1.2, 1.15, 0.0, 4.0, "new", 7),
+    ]
+    gateway = SimpleNamespace(
+        ensure_connection=lambda: None,
+        positions_get=lambda ticket=None, symbol=None: rows,
+        POSITION_TYPE_BUY=0,
+        POSITION_TYPE_SELL=1,
+    )
+
+    out = run_trade_get_open(
+        TradeGetOpenRequest(limit=2),
+        gateway=gateway,
+        use_client_tz=lambda: False,
+        format_time_minimal=lambda ts: f"t{int(ts)}",
+        format_time_minimal_local=lambda ts: f"lt{int(ts)}",
+        mt5_epoch_to_utc=lambda ts: ts,
+        normalize_limit=lambda value: value,
+        comment_row_metadata=lambda comment: {
+            "comment_visible_length": len(comment or ""),
+            "comment_max_length": 31,
+            "comment_may_be_truncated": False,
+        },
+    )
+
+    assert [row["Ticket"] for row in out] == [3, 4]
+    assert [row["Time"] for row in out] == ["t200", "t300"]
+
+
+def test_run_trade_get_pending_limit_prefers_latest_valid_timestamps() -> None:
+    Order = namedtuple(
+        "Order",
+        [
+            "ticket",
+            "symbol",
+            "time_setup",
+            "type",
+            "volume",
+            "price_open",
+            "sl",
+            "tp",
+            "price_current",
+            "comment",
+            "magic",
+        ],
+    )
+    rows = [
+        Order(11, "EURUSD", 100, 2, 0.1, 1.1, 1.0, 1.2, 1.15, "old", 7),
+        Order(12, "EURUSD", None, 2, 0.1, 1.1, 1.0, 1.2, 1.15, "missing", 7),
+        Order(13, "EURUSD", 200, 2, 0.1, 1.1, 1.0, 1.2, 1.15, "mid", 7),
+        Order(14, "EURUSD", 300, 2, 0.1, 1.1, 1.0, 1.2, 1.15, "new", 7),
+    ]
+    gateway = SimpleNamespace(
+        ensure_connection=lambda: None,
+        orders_get=lambda ticket=None, symbol=None: rows,
+        ORDER_TYPE_BUY=0,
+        ORDER_TYPE_SELL=1,
+        ORDER_TYPE_BUY_LIMIT=2,
+        ORDER_TYPE_SELL_LIMIT=3,
+        ORDER_TYPE_BUY_STOP=4,
+        ORDER_TYPE_SELL_STOP=5,
+        ORDER_TYPE_BUY_STOP_LIMIT=6,
+        ORDER_TYPE_SELL_STOP_LIMIT=7,
+    )
+
+    out = run_trade_get_pending(
+        TradeGetPendingRequest(limit=2),
+        gateway=gateway,
+        use_client_tz=lambda: False,
+        format_time_minimal=lambda ts: f"t{int(ts)}",
+        format_time_minimal_local=lambda ts: f"lt{int(ts)}",
+        mt5_epoch_to_utc=lambda ts: ts,
+        normalize_limit=lambda value: value,
+        comment_row_metadata=lambda comment: {
+            "comment_visible_length": len(comment or ""),
+            "comment_max_length": 31,
+            "comment_may_be_truncated": False,
+        },
+    )
+
+    assert [row["Ticket"] for row in out] == [13, 14]
+    assert [row["Time"] for row in out] == ["t200", "t300"]
+
+
 def test_trade_get_open_logs_finish_event(caplog) -> None:
     raw = _unwrap(core_trading_positions.trade_get_open)
 


### PR DESCRIPTION
## Summary
- truncated open and pending trade reads currently sort timestamps ascending and then take the tail
- pandas sorts `NaN` timestamps to the end by default, so undated rows can displace newer valid rows
- sort with `na_position="first"` so truncation keeps the newest valid timestamps first and only includes undated rows when there are not enough dated rows

## Root cause
`run_trade_get_open()` and `run_trade_get_pending()` both built a `__time_utc` column, called `sort_values("__time_utc")`, and then kept `tail(limit_value)`. Because pandas places `NaN` values at the end for ascending sorts, missing timestamps were treated as if they were newer than every dated row during truncation.

## Implemented solution
- changed both truncation sites to use a stable ascending sort with `na_position="first"`
- kept the existing retained-slice ordering semantics while preventing undated rows from pushing out newer valid timestamps
- added focused regressions for both open positions and pending orders with mixed dated/undated rows

## Trade-offs / limitations
- undated rows are still returned when there are fewer valid timestamps than the requested limit, which preserves current behavior for data sets that genuinely lack enough dated rows

## Report
- Resolves `code-reports/to-do/trading-use-cases-nan-sort-drops-records.md`