### PR TITLE
forecast: preserve horizon sigma scaling

### DIFF
--- a/src/mtdata/forecast/volatility.py
+++ b/src/mtdata/forecast/volatility.py
@@ -313,6 +313,11 @@ def _ewma_param_explanations(lambda_source: str) -> Dict[str, str]:
     return out
 
 
+def _annualize_horizon_sigma(horizon_sigma_return: float, bars_per_year: float) -> float:
+    """Express the horizon-scaled sigma on the annualized return scale."""
+    return float(horizon_sigma_return * math.sqrt(bars_per_year))
+
+
 def forecast_volatility(
     symbol: str,
     timeframe: TimeframeLiteral = "H1",
@@ -512,7 +517,7 @@ def forecast_volatility(
                 "sigma_bar_return": sigma_bar_return,
                 "sigma_annual_return": float(sigma_bar_return * math.sqrt(bpy)),
                 "horizon_sigma_return": horizon_sigma_return,
-                "horizon_sigma_annual": float(horizon_sigma_return * math.sqrt(bpy / max(1, int(horizon)))),
+                "horizon_sigma_annual": _annualize_horizon_sigma(horizon_sigma_return, bpy),
                 "params_used": {
                     "methods": base_methods,
                     "aggregator": aggregator,
@@ -708,7 +713,7 @@ def forecast_volatility(
             bpy = annualization_bars_per_year
             return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "proxy": proxy_l,
                     "horizon": int(horizon), "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
-                    "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
+                    "horizon_sigma_return": hsig, "horizon_sigma_annual": _annualize_horizon_sigma(hsig, bpy),
                     "params_used": p}
 
         # Direct volatility methods
@@ -799,7 +804,7 @@ def forecast_volatility(
                 params_used["halflife"] = halflife_used
             return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "horizon": int(horizon),
                     "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
-                    "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
+                    "horizon_sigma_return": hsig, "horizon_sigma_annual": _annualize_horizon_sigma(hsig, bpy),
                     "params_used": params_used,
                     "params_explained": _ewma_param_explanations(lambda_source),
                     "denoise_used": dn_spec_used}
@@ -835,7 +840,7 @@ def forecast_volatility(
             hsig = float(sbar * math.sqrt(max(1, int(horizon))))
             return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "horizon": int(horizon),
                     "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
-                    "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
+                    "horizon_sigma_return": hsig, "horizon_sigma_annual": _annualize_horizon_sigma(hsig, bpy),
                     "params_used": {"window": int(window)},
                     "denoise_used": dn_spec_used}
 
@@ -862,7 +867,7 @@ def forecast_volatility(
                 "sigma_bar_return": float(sigma_bar),
                 "sigma_annual_return": float(sigma_bar * math.sqrt(bpy)),
                 "horizon_sigma_return": float(sigma_h),
-                "horizon_sigma_annual": float(sigma_h * math.sqrt(bpy / max(1, int(horizon)))),
+                "horizon_sigma_annual": _annualize_horizon_sigma(float(sigma_h), bpy),
                 "params_used": {"window": int(window), "kernel": kernel, "bandwidth": bandwidth_val},
                 "denoise_used": dn_spec_used,
             }
@@ -902,7 +907,7 @@ def forecast_volatility(
                     params_used['o'] = int(p.get('o', 1))
                 return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "horizon": int(horizon),
                         "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
-                        "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
+                        "horizon_sigma_return": hsig, "horizon_sigma_annual": _annualize_horizon_sigma(hsig, bpy),
                         "params_used": params_used,
                         "denoise_used": dn_spec_used}
             except Exception as ex:
@@ -1057,7 +1062,7 @@ def forecast_volatility(
             bpy = annualization_bars_per_year
             return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "horizon": int(horizon),
                     "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
-                    "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
+                    "horizon_sigma_return": hsig, "horizon_sigma_annual": _annualize_horizon_sigma(hsig, bpy),
                     "params_used": {"rv_timeframe": rv_tf, "window_w": w, "window_m": m,
                                      "beta": [float(b) for b in beta.tolist()],
                                      "days": days},

--- a/tests/forecast/test_volatility_business_logic.py
+++ b/tests/forecast/test_volatility_business_logic.py
@@ -96,6 +96,7 @@ def test_forecast_volatility_general_theta_and_proxy_errors(monkeypatch):
     out = vol.forecast_volatility(
         symbol="EURUSD",
         timeframe="H1",
+        horizon=4,
         method="theta",
         proxy="squared_return",
         params={"alpha": 0.3},
@@ -107,8 +108,9 @@ def test_forecast_volatility_general_theta_and_proxy_errors(monkeypatch):
     expected_bpy = vol._bars_per_year("H1")
     assert out["sigma_annual_return"] == pytest.approx(out["sigma_bar_return"] * math.sqrt(expected_bpy))
     assert out["horizon_sigma_annual"] == pytest.approx(
-        out["horizon_sigma_return"] * math.sqrt(expected_bpy / max(1, int(out["horizon"])))
+        out["horizon_sigma_return"] * math.sqrt(expected_bpy)
     )
+    assert out["horizon_sigma_annual"] > out["sigma_annual_return"]
 
 
 def test_forecast_volatility_direct_methods_and_short_data(monkeypatch):
@@ -124,6 +126,7 @@ def test_forecast_volatility_direct_methods_and_short_data(monkeypatch):
     out = vol.forecast_volatility(
         symbol="EURUSD",
         timeframe="H1",
+        horizon=5,
         method="ewma",
         params='{"lookback": 80, "lambda_": 0.9}',
     )
@@ -136,8 +139,9 @@ def test_forecast_volatility_direct_methods_and_short_data(monkeypatch):
     expected_bpy = vol._bars_per_year("H1")
     assert out["sigma_annual_return"] == pytest.approx(out["sigma_bar_return"] * math.sqrt(expected_bpy))
     assert out["horizon_sigma_annual"] == pytest.approx(
-        out["horizon_sigma_return"] * math.sqrt(expected_bpy / max(1, int(out["horizon"])))
+        out["horizon_sigma_return"] * math.sqrt(expected_bpy)
     )
+    assert out["horizon_sigma_annual"] > out["sigma_annual_return"]
 
     out = vol.forecast_volatility(
         symbol="EURUSD",
@@ -240,11 +244,12 @@ def test_forecast_volatility_ensemble_aggregates_component_methods(monkeypatch):
     monkeypatch.setattr(vol.mt5, "last_error", lambda: (0, "ok"))
     monkeypatch.setattr(vol, "_mt5_copy_rates_from", lambda *args, **kwargs: _rates(240))
 
-    ewma = vol.forecast_volatility(symbol="EURUSD", timeframe="H1", method="ewma")
-    rolling_std = vol.forecast_volatility(symbol="EURUSD", timeframe="H1", method="rolling_std")
+    ewma = vol.forecast_volatility(symbol="EURUSD", timeframe="H1", horizon=5, method="ewma")
+    rolling_std = vol.forecast_volatility(symbol="EURUSD", timeframe="H1", horizon=5, method="rolling_std")
     ensemble = vol.forecast_volatility(
         symbol="EURUSD",
         timeframe="H1",
+        horizon=5,
         method="ensemble",
         params={
             "methods": ["ewma", "rolling_std"],
@@ -270,5 +275,6 @@ def test_forecast_volatility_ensemble_aggregates_component_methods(monkeypatch):
         ensemble["sigma_bar_return"] * math.sqrt(expected_bpy)
     )
     assert ensemble["horizon_sigma_annual"] == pytest.approx(
-        ensemble["horizon_sigma_return"] * math.sqrt(expected_bpy / max(1, int(ensemble["horizon"])))
+        ensemble["horizon_sigma_return"] * math.sqrt(expected_bpy)
     )
+    assert ensemble["horizon_sigma_annual"] > ensemble["sigma_annual_return"]

--- a/tests/forecast/test_volatility_extended.py
+++ b/tests/forecast/test_volatility_extended.py
@@ -624,8 +624,9 @@ class TestHarRvBlock:
             expected_bpy = _bars_per_year("H1")
             assert r["sigma_annual_return"] == pytest.approx(r["sigma_bar_return"] * math.sqrt(expected_bpy))
             assert r["horizon_sigma_annual"] == pytest.approx(
-                r["horizon_sigma_return"] * math.sqrt(expected_bpy / 5.0)
+                r["horizon_sigma_return"] * math.sqrt(expected_bpy)
             )
+            assert r["horizon_sigma_annual"] > r["sigma_annual_return"]
             assert "beta" in r["params_used"]
 
     def test_invalid_rv_timeframe(self):


### PR DESCRIPTION
## Summary
- `horizon_sigma_return` is already horizon-scaled in every volatility branch
- `horizon_sigma_annual` then multiplied that horizon-scaled value by `sqrt(bpy / horizon)`, which canceled the horizon back out
- annualize the horizon-scaled sigma consistently across all return paths so multi-bar horizons stay larger than the 1-bar annualized baseline

## Root cause
Several volatility branches computed `horizon_sigma_return` as a multi-bar sigma and then reused the 1-bar annualization factor by dividing through `sqrt(horizon)` again. That made `horizon_sigma_annual` collapse toward the same value as `sigma_annual_return`, defeating the purpose of carrying a horizon-scaled forecast.

## Implemented solution
- added a shared `_annualize_horizon_sigma()` helper in `forecast.volatility`
- reused it for ensemble, general-proxy, direct-estimator, realized-kernel, GARCH-family, and HAR-RV responses
- updated focused regressions to use multi-bar horizons in representative general, direct, ensemble, and HAR-RV paths and assert that the horizon-scaled annual value stays above the 1-bar annualized baseline

## Trade-offs / limitations
- this keeps the existing field name even though it represents an annualized horizon-scaled quantity rather than a normalized back-to-1-bar annualization

## Report
- Resolves `code-reports/to-do/volatility-horizon-sigma-annual-cancels.md`