### PR TITLE
core: retain tick dedup state

### DIFF
--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -1971,15 +1971,13 @@ def _merge_market_ticks(existing: List[Dict[str, Any]], new_ticks: List[Dict[str
     if not existing:
         return list(new_ticks)
     out = list(existing)
-    seen = {tuple(item["key"]) for item in existing[-_MARKET_BUFFER_EXTRA_TICKS:]}
+    seen = {tuple(item["key"]) for item in existing}
     for tick in new_ticks:
         key = tuple(tick["key"])
         if key in seen:
             continue
         out.append(tick)
         seen.add(key)
-        if len(seen) > _MARKET_BUFFER_EXTRA_TICKS * 4:
-            seen = {tuple(item["key"]) for item in out[-_MARKET_BUFFER_EXTRA_TICKS:]}
     return out
 
 

--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -857,9 +857,9 @@ def _refresh_market_state(
         )
         if isinstance(ticks_or_error, dict) and "error" in ticks_or_error:
             return ticks_or_error
-        merged = _merge_market_ticks(state.get("ticks", []), ticks_or_error)
-        trimmed = _trim_market_ticks(
-            ticks=merged,
+        trimmed = _merge_market_ticks(
+            state.get("ticks", []),
+            ticks_or_error,
             specs=[item for item in watch_for if item["symbol"] == symbol],
             observed_at_utc=observed_at_utc,
         )
@@ -1967,18 +1967,27 @@ def _normalize_tick_rows(rows: Any) -> List[Dict[str, Any]]:
     return normalized
 
 
-def _merge_market_ticks(existing: List[Dict[str, Any]], new_ticks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _merge_market_ticks(
+    existing: List[Dict[str, Any]],
+    new_ticks: List[Dict[str, Any]],
+    *,
+    specs: Optional[List[Dict[str, Any]]] = None,
+    observed_at_utc: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
     if not existing:
-        return list(new_ticks)
-    out = list(existing)
-    seen = {tuple(item["key"]) for item in existing}
-    for tick in new_ticks:
-        key = tuple(tick["key"])
-        if key in seen:
-            continue
-        out.append(tick)
-        seen.add(key)
-    return out
+        merged: List[Dict[str, Any]] = list(new_ticks)
+    else:
+        out = list(existing)
+        seen = {tuple(item["key"]) for item in existing}
+        for tick in new_ticks:
+            key = tuple(tick["key"])
+            if key not in seen:
+                out.append(tick)
+                seen.add(key)
+        merged = out
+    if specs is not None and observed_at_utc is not None:
+        merged = _trim_market_ticks(ticks=merged, specs=specs, observed_at_utc=observed_at_utc)
+    return merged
 
 
 def _trim_market_ticks(

--- a/tests/services/test_wait_event_use_cases.py
+++ b/tests/services/test_wait_event_use_cases.py
@@ -491,6 +491,58 @@ def test_merge_market_ticks_dedupes_rows_with_missing_volume_fields() -> None:
     assert len(merged) == 1
 
 
+def test_merge_market_ticks_keeps_older_existing_keys_in_seen_set(monkeypatch) -> None:
+    monkeypatch.setattr(wait_events_mod, "_MARKET_BUFFER_EXTRA_TICKS", 1)
+
+    existing = wait_events_mod._normalize_tick_rows(
+        [
+            {
+                "time": 100.0,
+                "time_msc": 100000,
+                "bid": 1.1,
+                "ask": 1.2,
+                "last": 1.15,
+            },
+            {
+                "time": 101.0,
+                "time_msc": 101000,
+                "bid": 1.11,
+                "ask": 1.21,
+                "last": 1.16,
+            },
+            {
+                "time": 102.0,
+                "time_msc": 102000,
+                "bid": 1.12,
+                "ask": 1.22,
+                "last": 1.17,
+            },
+        ]
+    )
+    incoming = wait_events_mod._normalize_tick_rows(
+        [
+            {
+                "time": 100.0,
+                "time_msc": 100000,
+                "bid": 1.1,
+                "ask": 1.2,
+                "last": 1.15,
+            },
+            {
+                "time": 103.0,
+                "time_msc": 103000,
+                "bid": 1.13,
+                "ask": 1.23,
+                "last": 1.18,
+            },
+        ]
+    )
+
+    merged = wait_events_mod._merge_market_ticks(existing, incoming)
+
+    assert [tick["time_msc"] for tick in merged] == [100000, 101000, 102000, 103000]
+
+
 def test_run_wait_event_uses_timeframe_as_boundary_when_watchers_are_inferred(monkeypatch) -> None:
     monkeypatch.setattr(
         "mtdata.core.wait_events._next_candle_wait_payload",


### PR DESCRIPTION
## Summary
- wait-events merged new market ticks against only a bounded suffix of the retained buffer
- once that suffix rolled forward, older retained keys could fall out of `seen`
- dedupe against the full retained tick set so older ticks cannot be appended again until trimming actually removes them

## Root cause
`_merge_market_ticks()` seeded and periodically rebuilt its `seen` set from only the last `_MARKET_BUFFER_EXTRA_TICKS` items in the retained output. If an older tick was still present in `out` but no longer in that suffix, a later fetch of the same tick would look new and get appended a second time.

## Implemented solution
- seed the dedup set from the full retained `existing` tick buffer
- keep it updated for the whole merged output instead of rebuilding from only the tail slice
- added a focused regression that shrinks `_MARKET_BUFFER_EXTRA_TICKS` and proves an older retained tick stays deduped while a genuinely new tick is still appended

## Trade-offs / limitations
- dedup now tracks every currently retained tick key, but the retained market buffer is already bounded by later trimming, so the extra set size stays limited to the active buffer rather than growing unbounded

## Report
- Resolves `code-reports/to-do/wait-events-tick-merge-duplicates.md`