### PR TITLE
forecast: skip dead HAR-RV fetches

### DIFF
--- a/src/mtdata/forecast/volatility.py
+++ b/src/mtdata/forecast/volatility.py
@@ -713,12 +713,13 @@ def forecast_volatility(
 
         if method_l == 'har_rv':
             dn_spec_used = None
+            denoise_columns_provided = isinstance(denoise, dict) and 'columns' in denoise
             if denoise is not None:
                 try:
                     dn_spec_used = _normalize_denoise_spec(denoise, default_when='pre_ti')
                 except Exception:
                     dn_spec_used = None
-                if dn_spec_used and not dn_spec_used.get('columns'):
+                if dn_spec_used and not denoise_columns_provided:
                     dn_spec_used['columns'] = ['open', 'high', 'low', 'close']
 
             try:

--- a/src/mtdata/forecast/volatility.py
+++ b/src/mtdata/forecast/volatility.py
@@ -711,6 +711,114 @@ def forecast_volatility(
                     "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
                     "params_used": p}
 
+        if method_l == 'har_rv':
+            dn_spec_used = None
+            if denoise is not None:
+                try:
+                    dn_spec_used = _normalize_denoise_spec(denoise, default_when='pre_ti')
+                except Exception:
+                    dn_spec_used = None
+                if dn_spec_used and not dn_spec_used.get('columns'):
+                    dn_spec_used['columns'] = ['open', 'high', 'low', 'close']
+
+            try:
+                rv_tf = str(p.get('rv_timeframe', 'M5')).upper()
+                rv_mt5_tf = TIMEFRAME_MAP.get(rv_tf)
+                if rv_mt5_tf is None:
+                    return {"error": f"Invalid rv_timeframe: {rv_tf}"}
+                days = int(p.get('days', 120))
+                w = int(p.get('window_w', 5))
+                m = int(p.get('window_m', 22))
+                rv_tf_secs = TIMEFRAME_SECONDS.get(rv_tf, 300)
+                bars_needed = int(days * max(1, (86400 // max(1, rv_tf_secs))) + 50)
+                _info_before = mt5.symbol_info(symbol)
+                _was_visible = bool(_info_before.visible) if _info_before is not None else None
+                err = _ensure_symbol_ready(symbol)
+                if err:
+                    return {"error": err}
+                try:
+                    if as_of:
+                        to_dt = _parse_start_datetime(as_of)
+                        if not to_dt:
+                            return {"error": "Invalid as_of time."}
+                        rates_rv = _mt5_copy_rates_from(symbol, rv_mt5_tf, to_dt, bars_needed)
+                    else:
+                        _tick = mt5.symbol_info_tick(symbol)
+                        if _tick is not None and getattr(_tick, 'time', None):
+                            t_utc = _mt5_epoch_to_utc(float(_tick.time))
+                            server_now_dt = datetime.fromtimestamp(t_utc, tz=timezone.utc)
+                        else:
+                            server_now_dt = datetime.now(timezone.utc)
+                        rates_rv = _mt5_copy_rates_from(symbol, rv_mt5_tf, server_now_dt, bars_needed)
+                finally:
+                    if _was_visible is False:
+                        try:
+                            mt5.symbol_select(symbol, False)
+                        except Exception:
+                            pass
+                if rates_rv is None or len(rates_rv) < 50:
+                    return {"error": f"Failed to get intraday rates for RV: {mt5.last_error()}"}
+                dfrv = pd.DataFrame(rates_rv)
+                if as_of is None and len(dfrv) >= 2:
+                    dfrv = dfrv.iloc[:-1]
+                if dn_spec_used:
+                    try:
+                        _apply_denoise(dfrv, dn_spec_used, default_when='pre_ti')
+                    except Exception:
+                        pass
+                c = dfrv['close'].astype(float).to_numpy()
+                if c.size < 10:
+                    return {"error": "Insufficient intraday bars for RV"}
+                rr = _log_returns_from_prices(c)
+                rr = rr[np.isfinite(rr)]
+                dt = pd.to_datetime(dfrv['time'].iloc[1:].astype(float), unit='s', utc=True)
+                days_idx = pd.DatetimeIndex(dt).floor('D')
+                df_r = pd.DataFrame({'day': days_idx, 'r2': rr * rr})
+                daily_rv = df_r.groupby('day')['r2'].sum().astype(float)
+                if len(daily_rv) < max(30, m + 5):
+                    return {"error": "Not enough daily RV observations for HAR-RV"}
+                RV = daily_rv.to_numpy(dtype=float)
+                Dlag = RV[:-1]
+
+                def rmean(arr, k):
+                    s = pd.Series(arr)
+                    return s.rolling(window=k, min_periods=k).mean().to_numpy()
+
+                Wlag_full = rmean(RV, w)
+                Mlag_full = rmean(RV, m)
+                y = RV[1:]
+                Wlag = Wlag_full[:-1]
+                Mlag = Mlag_full[:-1]
+                Xd = Dlag
+                mask = np.isfinite(Xd) & np.isfinite(Wlag) & np.isfinite(Mlag) & np.isfinite(y)
+                X = np.vstack([np.ones_like(Xd[mask]), Xd[mask], Wlag[mask], Mlag[mask]]).T
+                yv = y[mask]
+                if X.shape[0] < 20:
+                    return {"error": "Insufficient samples after alignment for HAR-RV"}
+                beta, *_ = np.linalg.lstsq(X, yv, rcond=None)
+                D_last = RV[-1]
+                W_last = float(pd.Series(RV).tail(w).mean())
+                M_last = float(pd.Series(RV).tail(m).mean())
+                rv_next = float(beta[0] + beta[1]*D_last + beta[2]*W_last + beta[3]*M_last)
+                rv_next = max(0.0, rv_next)
+                tf_secs = TIMEFRAME_SECONDS.get(timeframe)
+                if not tf_secs:
+                    return {"error": unsupported_timeframe_seconds_error(timeframe)}
+                bars_per_day = float(86400.0 / float(tf_secs))
+                sbar = float(math.sqrt(rv_next / bars_per_day))
+                h_days = float(int(horizon)) / bars_per_day
+                hsig = float(math.sqrt(rv_next * max(h_days, 0.0)))
+                bpy = annualization_bars_per_year
+                return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "horizon": int(horizon),
+                        "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
+                        "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
+                        "params_used": {"rv_timeframe": rv_tf, "window_w": w, "window_m": m,
+                                         "beta": [float(b) for b in beta.tolist()],
+                                         "days": days},
+                        "denoise_used": dn_spec_used}
+            except Exception as ex:
+                return {"error": f"HAR-RV error: {ex}"}
+
         # Direct volatility methods
         # Fetch history sized by method
         def _need_bars_direct() -> int:
@@ -908,162 +1016,7 @@ def forecast_volatility(
             except Exception as ex:
                 return {"error": f"{method_l} error: {ex}"}
 
-        if method_l != 'har_rv':
-            return {"error": f"Unsupported direct volatility method: {method_l}"}
-
-        # HAR-RV is the only direct method that still uses the legacy second-stage
-        # fetch path before its dedicated intraday RV fetch below.
-        fit_bars = int(p.get('fit_bars', 2000))
-        need = max(fit_bars + 2, 500)
-
-        # Ensure symbol is ready; remember original visibility to restore later
-        _info_before = mt5.symbol_info(symbol)
-        _was_visible = bool(_info_before.visible) if _info_before is not None else None
-        err = _ensure_symbol_ready(symbol)
-        if err:
-            return {"error": err}
-
-        try:
-            # Use explicit as-of time if provided, else server time for alignment
-            if as_of:
-                to_dt = _parse_start_datetime(as_of)
-                if not to_dt:
-                    return {"error": "Invalid as_of_datetime. Try '2025-08-29', '2025-08-29 14:30', 'yesterday 14:00'."}
-                rates = _mt5_copy_rates_from(symbol, mt5_tf, to_dt, need)
-            else:
-                _tick = mt5.symbol_info_tick(symbol)
-                if _tick is not None and getattr(_tick, 'time', None):
-                    t_utc = _mt5_epoch_to_utc(float(_tick.time))
-                    server_now_dt = datetime.fromtimestamp(t_utc, tz=timezone.utc)
-                else:
-                    server_now_dt = datetime.now(timezone.utc)
-                rates = _mt5_copy_rates_from(symbol, mt5_tf, server_now_dt, need)
-        finally:
-            if _was_visible is False:
-                try:
-                    mt5.symbol_select(symbol, False)
-                except Exception:
-                    pass
-
-        if rates is None or len(rates) < 3:
-            return {"error": f"Failed to get sufficient rates for {symbol}: {mt5.last_error()}"}
-
-        df = pd.DataFrame(rates)
-        # Drop forming last bar only when using current 'now' as anchor; keep all for historical as_of
-        if as_of is None and len(df) >= 2:
-            df = df.iloc[:-1]
-        if len(df) < 3:
-            return {"error": "Not enough closed bars to compute volatility"}
-
-        # Optionally denoise relevant columns prior to volatility estimation
-        __stage = 'denoise'
-        if denoise:
-            try:
-                # Default columns by method if user didn't provide
-                _spec = dict(denoise)
-                if 'columns' not in _spec or not _spec.get('columns'):
-                    if method_l in ('ewma', 'garch'):
-                        _spec['columns'] = ['close']
-                    else:  # range-based estimators rely on OHLC
-                        _spec['columns'] = ['open', 'high', 'low', 'close']
-                _apply_denoise(df, _spec, default_when='pre_ti')
-            except Exception:
-                # Fail-safe: ignore denoise errors and proceed with raw data
-                pass
-
-        # HAR-RV on daily realized variance computed from intraday returns
-        try:
-            rv_tf = str(p.get('rv_timeframe', 'M5')).upper()
-            rv_mt5_tf = TIMEFRAME_MAP.get(rv_tf)
-            if rv_mt5_tf is None:
-                return {"error": f"Invalid rv_timeframe: {rv_tf}"}
-            days = int(p.get('days', 120))
-            w = int(p.get('window_w', 5))
-            m = int(p.get('window_m', 22))
-            rv_tf_secs = TIMEFRAME_SECONDS.get(rv_tf, 300)
-            bars_needed = int(days * max(1, (86400 // max(1, rv_tf_secs))) + 50)
-            _info_before = mt5.symbol_info(symbol)
-            _was_visible = bool(_info_before.visible) if _info_before is not None else None
-            err = _ensure_symbol_ready(symbol)
-            if err:
-                return {"error": err}
-            try:
-                if as_of:
-                    to_dt = _parse_start_datetime(as_of)
-                    if not to_dt:
-                        return {"error": "Invalid as_of time."}
-                    rates_rv = _mt5_copy_rates_from(symbol, rv_mt5_tf, to_dt, bars_needed)
-                else:
-                    _tick = mt5.symbol_info_tick(symbol)
-                    if _tick is not None and getattr(_tick, 'time', None):
-                        t_utc = _mt5_epoch_to_utc(float(_tick.time))
-                        server_now_dt = datetime.fromtimestamp(t_utc, tz=timezone.utc)
-                    else:
-                        server_now_dt = datetime.now(timezone.utc)
-                    rates_rv = _mt5_copy_rates_from(symbol, rv_mt5_tf, server_now_dt, bars_needed)
-            finally:
-                if _was_visible is False:
-                    try:
-                        mt5.symbol_select(symbol, False)
-                    except Exception:
-                        pass
-            if rates_rv is None or len(rates_rv) < 50:
-                return {"error": f"Failed to get intraday rates for RV: {mt5.last_error()}"}
-            dfrv = pd.DataFrame(rates_rv)
-            if as_of is None and len(dfrv) >= 2:
-                dfrv = dfrv.iloc[:-1]
-            c = dfrv['close'].astype(float).to_numpy()
-            if c.size < 10:
-                return {"error": "Insufficient intraday bars for RV"}
-            rr = _log_returns_from_prices(c)
-            rr = rr[np.isfinite(rr)]
-            dt = pd.to_datetime(dfrv['time'].iloc[1:].astype(float), unit='s', utc=True)
-            days_idx = pd.DatetimeIndex(dt).floor('D')
-            df_r = pd.DataFrame({'day': days_idx, 'r2': rr * rr})
-            daily_rv = df_r.groupby('day')['r2'].sum().astype(float)
-            if len(daily_rv) < max(30, m + 5):
-                return {"error": "Not enough daily RV observations for HAR-RV"}
-            RV = daily_rv.to_numpy(dtype=float)
-            Dlag = RV[:-1]
-
-            def rmean(arr, k):
-                s = pd.Series(arr)
-                return s.rolling(window=k, min_periods=k).mean().to_numpy()
-
-            Wlag_full = rmean(RV, w)
-            Mlag_full = rmean(RV, m)
-            y = RV[1:]
-            Wlag = Wlag_full[:-1]
-            Mlag = Mlag_full[:-1]
-            Xd = Dlag
-            mask = np.isfinite(Xd) & np.isfinite(Wlag) & np.isfinite(Mlag) & np.isfinite(y)
-            X = np.vstack([np.ones_like(Xd[mask]), Xd[mask], Wlag[mask], Mlag[mask]]).T
-            yv = y[mask]
-            if X.shape[0] < 20:
-                return {"error": "Insufficient samples after alignment for HAR-RV"}
-            beta, *_ = np.linalg.lstsq(X, yv, rcond=None)
-            D_last = RV[-1]
-            W_last = float(pd.Series(RV).tail(w).mean())
-            M_last = float(pd.Series(RV).tail(m).mean())
-            rv_next = float(beta[0] + beta[1]*D_last + beta[2]*W_last + beta[3]*M_last)
-            rv_next = max(0.0, rv_next)
-            tf_secs = TIMEFRAME_SECONDS.get(timeframe)
-            if not tf_secs:
-                return {"error": unsupported_timeframe_seconds_error(timeframe)}
-            bars_per_day = float(86400.0 / float(tf_secs))
-            sbar = float(math.sqrt(rv_next / bars_per_day))
-            h_days = float(int(horizon)) / bars_per_day
-            hsig = float(math.sqrt(rv_next * max(h_days, 0.0)))
-            bpy = annualization_bars_per_year
-            return {"success": True, "symbol": symbol, "timeframe": timeframe, "method": method_l, "horizon": int(horizon),
-                    "sigma_bar_return": sbar, "sigma_annual_return": float(sbar*math.sqrt(bpy)),
-                    "horizon_sigma_return": hsig, "horizon_sigma_annual": float(hsig*math.sqrt(bpy/max(1,int(horizon)))),
-                    "params_used": {"rv_timeframe": rv_tf, "window_w": w, "window_m": m,
-                                     "beta": [float(b) for b in beta.tolist()],
-                                     "days": days},
-                    "denoise_used": dn_spec_used}
-        except Exception as ex:
-            return {"error": f"HAR-RV error: {ex}"}
+        return {"error": f"Unsupported direct volatility method: {method_l}"}
     except Exception as e:
         return {"error": f"Error computing volatility forecast: {str(e)}"}
 

--- a/tests/forecast/test_volatility_extended.py
+++ b/tests/forecast/test_volatility_extended.py
@@ -519,9 +519,8 @@ class TestHarRvSecondSection:
 
     def test_second_section_as_of(self):
         """as_of triggers the historical copy path inside the HAR-RV second fetch."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
-        with _mock_env(rates_side_effect=[std, std, intraday],
+        with _mock_env(rates_side_effect=[intraday],
                        parse_dt_return=datetime(2024, 6, 1, tzinfo=timezone.utc)):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv",
                                     as_of="2024-06-01")
@@ -536,28 +535,25 @@ class TestHarRvSecondSection:
 
     def test_second_section_tick_no_time(self):
         """tick.time being None causes a fallback to datetime.now."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
         with _mock_env(tick_time=None,
-                       rates_side_effect=[std, std, intraday]):
+                       rates_side_effect=[intraday]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert r.get("success") is True or "error" in r
 
     def test_second_section_visibility_restore(self):
         """When symbol was not visible, symbol_select is called to restore state."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
         with _mock_env(info_visible=False,
-                       rates_side_effect=[std, std, intraday]) as env:
+                       rates_side_effect=[intraday]) as env:
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert env["mt5"].symbol_select.called
 
     def test_second_section_visibility_restore_exc(self):
         """An exception from symbol_select during visibility restore is silently ignored."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
         with _mock_env(info_visible=False,
-                       rates_side_effect=[std, std, intraday],
+                       rates_side_effect=[intraday],
                        select_side_effect=RuntimeError("boom")):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             # Function should not crash
@@ -565,24 +561,21 @@ class TestHarRvSecondSection:
 
     def test_second_section_insufficient_rates(self):
         """None returned from the intraday rate fetch produces an error response."""
-        std = _make_rates(200)
-        with _mock_env(rates_side_effect=[std, None]):
+        with _mock_env(rates_side_effect=[None]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
 
     def test_second_section_few_bars(self):
         """Fewer than 3 bars after dropping the forming bar yields an error."""
-        std = _make_rates(200)
         tiny = _make_rates(3)
-        with _mock_env(rates_side_effect=[std, tiny]):
+        with _mock_env(rates_side_effect=[tiny]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
 
     def test_second_section_denoise(self):
         """A denoise spec is applied during the HAR-RV second section."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
-        with _mock_env(rates_side_effect=[std, std, intraday]):
+        with _mock_env(rates_side_effect=[intraday]):
             with patch(f"{MOD}._apply_denoise"):
                 r = forecast_volatility("EURUSD", "H1", 5, method="har_rv",
                                         denoise={"method": "wavelet"})
@@ -590,9 +583,8 @@ class TestHarRvSecondSection:
 
     def test_second_section_denoise_error(self):
         """A denoise error in the HAR-RV second section is silently ignored."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
-        with _mock_env(rates_side_effect=[std, std, intraday]):
+        with _mock_env(rates_side_effect=[intraday]):
             with patch(f"{MOD}._apply_denoise", side_effect=RuntimeError("x")):
                 r = forecast_volatility("EURUSD", "H1", 5, method="har_rv",
                                         denoise={"method": "wavelet"})
@@ -609,10 +601,9 @@ class TestHarRvBlock:
 
     @staticmethod
     def _har_rv_side_effect(n_intraday=15000):
-        """Standard side_effect list for the three _mt5_copy_rates_from calls."""
-        std = _make_rates(200, seed=42)
+        """Standard intraday side effect for the HAR-RV fetch."""
         intraday = _make_rates(n_intraday, bar_secs=300, seed=99)
-        return [std, std, intraday]
+        return [intraday]
 
     def test_success(self):
         """Lines 1085-1178: HAR-RV happy path."""
@@ -637,7 +628,7 @@ class TestHarRvBlock:
 
     def test_ensure_error_intraday(self):
         """Line 1100-1101: ensure error during intraday fetch."""
-        with _mock_env(ensure_side_effect=[None, None, "RV symbol err"],
+        with _mock_env(ensure_side_effect=["RV symbol err"],
                        rates_side_effect=self._har_rv_side_effect()):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
@@ -652,16 +643,9 @@ class TestHarRvBlock:
 
     def test_invalid_as_of_intraday(self):
         """Lines 1105-1106: invalid as_of returns error in intraday fetch."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
-        # First two fetches succeed (they use as_of and parse_dt_return),
-        # but the third fetch uses as_of again.
-        # We mock parse_dt to return a valid datetime for the first two calls
-        # and None for the third. Use side_effect:
-        dt_ok = datetime(2024, 3, 1, tzinfo=timezone.utc)
-        with _mock_env(rates_side_effect=[std, std, intraday]):
-            with patch(f"{MOD}._parse_start_datetime",
-                       side_effect=[dt_ok, dt_ok, None]):
+        with _mock_env(rates_side_effect=[intraday]):
+            with patch(f"{MOD}._parse_start_datetime", return_value=None):
                 r = forecast_volatility("EURUSD", "H1", 5, method="har_rv",
                                         as_of="2024-03-01")
                 assert "error" in r
@@ -690,41 +674,36 @@ class TestHarRvBlock:
 
     def test_insufficient_intraday_rates(self):
         """Line 1122-1123: < 50 intraday bars."""
-        std = _make_rates(200)
         tiny = _make_rates(30, bar_secs=300)
-        with _mock_env(rates_side_effect=[std, std, tiny]):
+        with _mock_env(rates_side_effect=[tiny]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
 
     def test_insufficient_intraday_rates_none(self):
         """Line 1122: rates_rv is None."""
-        std = _make_rates(200)
-        with _mock_env(rates_side_effect=[std, std, None]):
+        with _mock_env(rates_side_effect=[None]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
 
     def test_insufficient_daily_rv(self):
         """Line 1136-1137: not enough daily RV observations."""
-        std = _make_rates(200)
         # 100 M5 bars ≈ 0.35 day → 1 daily group < 30
         tiny_intra = _make_rates(100, bar_secs=300)
-        with _mock_env(rates_side_effect=[std, std, tiny_intra]):
+        with _mock_env(rates_side_effect=[tiny_intra]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r and "daily RV" in r.get("error", "")
 
     def test_insufficient_alignment_samples(self):
         """Line 1154-1155: < 20 usable samples after NaN masking."""
-        std = _make_rates(200)
         # 9000 M5 bars ≈ 31 days; with default window_m=22, only ~9 aligned.
         short_intra = _make_rates(9000, bar_secs=300, seed=77)
-        with _mock_env(rates_side_effect=[std, std, short_intra]):
+        with _mock_env(rates_side_effect=[short_intra]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
 
     def test_exception_handler(self):
         """Lines 1179-1180: generic exception caught."""
-        std = _make_rates(200)
-        with _mock_env(rates_side_effect=[std, std, _make_rates(15000, bar_secs=300)]):
+        with _mock_env(rates_side_effect=[_make_rates(15000, bar_secs=300)]):
             with patch(f"{MOD}.TIMEFRAME_MAP") as mock_map:
                 # Make TIMEFRAME_MAP.get succeed for 'H1' but return None
                 # for the rv_timeframe lookup after validation
@@ -738,15 +717,20 @@ class TestHarRvBlock:
 
     def test_custom_rv_params(self):
         """Custom rv_timeframe, days, window_w, window_m."""
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
-        with _mock_env(rates_side_effect=[std, std, intraday]):
+        with _mock_env(rates_side_effect=[intraday]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv",
                                     params={"rv_timeframe": "M5",
                                             "days": 60,
                                             "window_w": 3,
                                             "window_m": 10})
             assert r.get("success") is True or "error" in r
+
+    def test_har_rv_uses_single_rate_fetch(self):
+        with _mock_env(rates_side_effect=self._har_rv_side_effect()) as env:
+            r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
+            assert isinstance(r, dict)
+            assert env["copy_rates"].call_count == 1
 
     def test_as_of_keeps_all_bars(self):
         """Lines 1125-1126: as_of set → last bar NOT dropped."""
@@ -758,7 +742,7 @@ class TestHarRvBlock:
 
     def test_horizon_sigma_scaling(self):
         """Lines 1169-1170: horizon sigma scales with horizon."""
-        with _mock_env(rates_side_effect=self._har_rv_side_effect()):
+        with _mock_env(rates_side_effect=self._har_rv_side_effect() * 2):
             r1 = forecast_volatility("EURUSD", "H1", 1, method="har_rv")
             r5 = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             if r1.get("success") and r5.get("success"):
@@ -773,9 +757,8 @@ class TestSecondSectionDenoiseDetails:
     """Denoise column-defaulting logic in the second fetch section."""
 
     def _make_side_effect(self):
-        std = _make_rates(200)
         intraday = _make_rates(15000, bar_secs=300, seed=99)
-        return [std, std, intraday]
+        return [intraday]
 
     def test_denoise_spec_columns_default_for_har_rv(self):
         """Lines 1004-1008: columns default to OHLC for non-ewma, non-garch."""

--- a/tests/forecast/test_volatility_extended.py
+++ b/tests/forecast/test_volatility_extended.py
@@ -491,8 +491,8 @@ class TestTheta:
 # ===================================================================
 
 class TestHarRvSecondSection:
-    """har_rv is the only method that falls through the first direct-methods
-    section into the legacy second-stage fetch section."""
+    """har_rv uses a single dedicated intraday-fetch path; these tests cover the
+    branching logic within that path (ensure errors, as_of, tick fallback, etc.)."""
 
     def test_ewma_does_not_fall_through_to_second_section(self):
         std = _make_rates(200)
@@ -512,8 +512,8 @@ class TestHarRvSecondSection:
         assert abs(r["params_used"]["lambda_"] - custom_lam) < 1e-9
 
     def test_second_section_ensure_error(self):
-        """_ensure_symbol_ready error in the HAR-RV second fetch returns an error."""
-        with _mock_env(ensure_side_effect=[None, "Symbol locked"]):
+        """_ensure_symbol_ready error in the HAR-RV intraday fetch returns an error."""
+        with _mock_env(ensure_side_effect=["Symbol locked"]):
             r = forecast_volatility("EURUSD", "H1", 5, method="har_rv")
             assert "error" in r
 


### PR DESCRIPTION
## Summary
- HAR-RV still fell through the generic direct-volatility fetch path before running its own dedicated intraday RV fetch
- neither of those earlier H1 fetches contributed to the HAR-RV output
- moved HAR-RV onto its dedicated intraday path directly and added a regression that proves it now uses a single MT5 rates fetch

## Root cause
`forecast_volatility()` treated `har_rv` as a direct volatility method, so it executed the generic direct-method fetch block and then a second legacy fetch block before finally performing the intraday RV fetch that actually drives HAR-RV. The intermediate bars and denoise application were dead work because HAR-RV only consumed the later intraday series.

## Implemented solution
- short-circuited `har_rv` onto its own dedicated intraday branch before the generic direct-method fetch block
- applied optional denoise handling to the actual intraday frame used by HAR-RV instead of an unused intermediate frame
- removed the dead legacy second-fetch section
- updated HAR-RV tests to use the real intraday-only fixture shape and added an explicit `copy_rates` call-count regression

## Trade-offs / limitations
- this keeps the current HAR-RV output contract and error handling intact; it only removes unused MT5 round-trips and moves denoise onto the data HAR-RV already consumes

## Report
- Resolves `code-reports/to-do/16-har-rv-triple-mt5-fetch.md`