### PR TITLE
forecast: surface CI diagnostics

### DIFF
--- a/src/mtdata/forecast/common.py
+++ b/src/mtdata/forecast/common.py
@@ -31,6 +31,44 @@ def edge_pad_to_length(values: np.ndarray, length: int) -> np.ndarray:
     return np.pad(vals, (0, target - vals.size), mode='edge').astype(float, copy=False)
 
 
+def build_ci_diagnostics(
+    *,
+    provider: str,
+    requested: bool,
+    available: bool,
+    status: str,
+    alpha: Optional[float] = None,
+    coverage: Optional[float] = None,
+    level: Optional[int] = None,
+    warning: Optional[str] = None,
+    error: Optional[str] = None,
+    error_type: Optional[str] = None,
+    interval_columns: Optional[List[Any]] = None,
+) -> Dict[str, Any]:
+    """Build standardized CI diagnostics metadata for forecast method results."""
+    ci_diag: Dict[str, Any] = {
+        "provider": str(provider),
+        "requested": bool(requested),
+        "available": bool(available),
+        "status": str(status),
+    }
+    if alpha is not None:
+        ci_diag["alpha"] = float(alpha)
+    if coverage is not None:
+        ci_diag["coverage"] = float(coverage)
+    if level is not None:
+        ci_diag["level"] = int(level)
+    if warning:
+        ci_diag["warning"] = str(warning)
+    if error:
+        ci_diag["error"] = str(error)
+    if error_type:
+        ci_diag["error_type"] = str(error_type)
+    if interval_columns:
+        ci_diag["interval_columns"] = [str(col) for col in interval_columns]
+    return {"diagnostics": {"ci": ci_diag}}
+
+
 def log_returns_from_prices(prices: np.ndarray, eps: float = 1e-12) -> np.ndarray:
     """Compute consecutive log-returns from a price array."""
     arr = np.asarray(prices, dtype=float).ravel()

--- a/src/mtdata/forecast/common.py
+++ b/src/mtdata/forecast/common.py
@@ -64,7 +64,7 @@ def build_ci_diagnostics(
         ci_diag["error"] = str(error)
     if error_type:
         ci_diag["error_type"] = str(error_type)
-    if interval_columns:
+    if interval_columns is not None:
         ci_diag["interval_columns"] = [str(col) for col in interval_columns]
     return {"diagnostics": {"ci": ci_diag}}
 

--- a/src/mtdata/forecast/methods/sktime.py
+++ b/src/mtdata/forecast/methods/sktime.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Optional, List
+import logging
 import warnings
 import numpy as np
 import pandas as pd
 
+from ..common import build_ci_diagnostics as _build_ci_diagnostics
 from ..interface import ForecastMethod, ForecastResult
 from ..registry import ForecastRegistry
 
@@ -15,6 +17,7 @@ except Exception:
     _HAS_SKTIME = False
 
 _SKTIME_IMPORT_ERROR = "sktime is not installed; install it to enable sktime-based forecast methods."
+logger = logging.getLogger(__name__)
 
 class SktimeMethod(ForecastMethod):
     """Base class for Sktime methods."""
@@ -133,12 +136,15 @@ class SktimeMethod(ForecastMethod):
                 
             # CI extraction
             ci_values = None
+            metadata: Dict[str, Any] = {}
             ci_alpha = kwargs.get('ci_alpha', params.get('ci_alpha'))
             if ci_alpha is not None:
+                ci_alpha_value: Optional[float] = None
                 try:
                     # sktime predict_interval returns DataFrame with MultiIndex columns (coverage, lower/upper)
                     # coverage is 1 - alpha? No, coverage is e.g. 0.9 for alpha 0.1
-                    coverage = 1.0 - float(ci_alpha)
+                    ci_alpha_value = float(ci_alpha)
+                    coverage = 1.0 - ci_alpha_value
                     intervals = estimator.predict_interval(fh=fh, X=X_future, coverage=coverage)
                     # intervals columns: (var_name, coverage, 'lower'/'upper')
                     # We assume univariate
@@ -152,10 +158,11 @@ class SktimeMethod(ForecastMethod):
                     # Let's try to find them dynamically
                     lo_vals = None
                     hi_vals = None
+                    interval_columns = [str(col) for col in cols]
                     
                     for col in cols:
                         # col is a tuple
-                        if len(col) >= 3:
+                        if isinstance(col, tuple) and len(col) >= 3:
                             cov = col[1]
                             direction = col[2]
                             if abs(cov - coverage) < 1e-6:
@@ -165,15 +172,54 @@ class SktimeMethod(ForecastMethod):
                                     hi_vals = intervals[col].values
                     
                     if lo_vals is not None and hi_vals is not None:
-                         ci_values = (lo_vals.astype(float), hi_vals.astype(float))
-                         
-                except Exception:
-                    pass
+                        ci_values = (lo_vals.astype(float), hi_vals.astype(float))
+                        metadata = _build_ci_diagnostics(
+                            provider=self.name,
+                            requested=True,
+                            available=True,
+                            status="available",
+                            alpha=ci_alpha_value,
+                            coverage=coverage,
+                        )
+                    else:
+                        warning_text = (
+                            f"Sktime {self.name} did not return matching interval columns for coverage "
+                            f"{coverage:g}; returning point forecast only."
+                        )
+                        logger.warning("%s Columns=%s", warning_text, interval_columns)
+                        metadata = _build_ci_diagnostics(
+                            provider=self.name,
+                            requested=True,
+                            available=False,
+                            status="unavailable",
+                            alpha=ci_alpha_value,
+                            coverage=coverage,
+                            warning=warning_text,
+                            interval_columns=interval_columns,
+                        )
+
+                except Exception as ex:
+                    warning_text = (
+                        f"Sktime {self.name} confidence interval extraction failed: {ex}. "
+                        "Returning point forecast only."
+                    )
+                    logger.warning("%s", warning_text)
+                    metadata = _build_ci_diagnostics(
+                        provider=self.name,
+                        requested=True,
+                        available=False,
+                        status="error",
+                        alpha=ci_alpha_value,
+                        warning=warning_text,
+                        error=str(ex),
+                        error_type=type(ex).__name__,
+                    )
 
             return ForecastResult(
                 forecast=f_vals,
                 ci_values=ci_values,
-                params_used={"seasonality": seasonality, **params}
+                params_used={"seasonality": seasonality, **params},
+                metadata=metadata or None,
             )
             
         except Exception as ex:

--- a/src/mtdata/forecast/methods/statsforecast.py
+++ b/src/mtdata/forecast/methods/statsforecast.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Tuple, List
 import json
+import logging
 import warnings
 import numpy as np
 import pandas as pd
 import inspect
 
-from ..common import edge_pad_to_length as _edge_pad_to_length
+from ..common import build_ci_diagnostics as _build_ci_diagnostics, edge_pad_to_length as _edge_pad_to_length
 from ..interface import ForecastMethod, ForecastResult
 from ..registry import ForecastRegistry
+
+logger = logging.getLogger(__name__)
 
 
 def _coerce_param_value(value: Any) -> Any:
@@ -138,6 +141,7 @@ class StatsForecastMethod(ForecastMethod):
             
             # CI extraction
             ci_values = None
+            metadata: Dict[str, Any] = {}
             if level:
                 lev_val = level[0]
                 cols = Yf.columns
@@ -157,6 +161,31 @@ class StatsForecastMethod(ForecastMethod):
                     hi_vals = _edge_pad_to_length(hi_vals, int(horizon))
                         
                     ci_values = (lo_vals.astype(float), hi_vals.astype(float))
+                    metadata = _build_ci_diagnostics(
+                        provider=self.name,
+                        requested=True,
+                        available=True,
+                        status="available",
+                        alpha=alpha_val,
+                        level=lev_val,
+                    )
+                else:
+                    interval_columns = [str(col) for col in cols]
+                    warning_text = (
+                        f"StatsForecast {self.name} did not return matching interval columns for level "
+                        f"{lev_val}; returning point forecast only."
+                    )
+                    logger.warning("%s Columns=%s", warning_text, interval_columns)
+                    metadata = _build_ci_diagnostics(
+                        provider=self.name,
+                        requested=True,
+                        available=False,
+                        status="unavailable",
+                        alpha=alpha_val,
+                        level=lev_val,
+                        warning=warning_text,
+                        interval_columns=interval_columns,
+                    )
 
             # Filter out internal context params and build clean params_used
             internal_keys = {'symbol', 'timeframe', 'as_of', 'exog_used', 'exog_future', 'seasonality'}
@@ -166,7 +195,8 @@ class StatsForecastMethod(ForecastMethod):
             return ForecastResult(
                 forecast=f_vals,
                 ci_values=ci_values,
-                params_used=params_used
+                params_used=params_used,
+                metadata=metadata or None,
             )
             
         except Exception as ex:

--- a/tests/forecast/test_forecast_common_coverage.py
+++ b/tests/forecast/test_forecast_common_coverage.py
@@ -13,6 +13,7 @@ import pytest
 # Imports under test
 # ---------------------------------------------------------------------------
 from mtdata.forecast.common import (
+    build_ci_diagnostics,
     edge_pad_to_length,
     log_returns_from_prices,
     _normalize_weights,
@@ -41,6 +42,22 @@ from mtdata.forecast.forecast_preprocessing import (
 )
 
 RS = np.random.RandomState(42)
+
+
+# ===================================================================
+# 0. build_ci_diagnostics
+# ===================================================================
+class TestBuildCiDiagnostics:
+    def test_preserves_explicit_empty_interval_columns(self):
+        result = build_ci_diagnostics(
+            provider="statsforecast",
+            requested=True,
+            available=False,
+            status="missing",
+            interval_columns=[],
+        )
+
+        assert result["diagnostics"]["ci"]["interval_columns"] == []
 
 
 # ===================================================================

--- a/tests/forecast/test_sktime_coverage.py
+++ b/tests/forecast/test_sktime_coverage.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import importlib
 import sys
 import types
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -80,18 +79,17 @@ for name, mod in _STUBS.items():
     sys.modules[name] = mod
 
 # Patch _HAS_SKTIME before importing sktime module
-import mtdata.forecast.methods.sktime as _sktime_mod
+import mtdata.forecast.methods.sktime as _sktime_mod  # noqa: E402
 _orig_has_sktime = _sktime_mod._HAS_SKTIME
 _sktime_mod._HAS_SKTIME = True
 
-from mtdata.forecast.methods.sktime import (
-    SktimeMethod,
+from mtdata.forecast.methods.sktime import (  # noqa: E402
     GenericSktimeMethod,
     SktThetaMethod,
     SktNaiveMethod,
     SktAutoETSMethod,
 )
-from mtdata.forecast.interface import ForecastResult
+from mtdata.forecast.interface import ForecastResult  # noqa: E402
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -150,7 +148,6 @@ class TestGenericSktimeGetEstimator:
 
     def test_sp_injection(self):
         """sp should be injected if estimator accepts it."""
-        import inspect
         # Patch signature to accept sp
         _FakeThetaForecaster.__init__ = lambda self, sp=1, **kw: _FakeForecaster.__init__(self, sp=sp, **kw)
         try:
@@ -257,6 +254,8 @@ class TestSktimeMethodForecast:
         lo, hi = res.ci_values
         assert len(lo) == 5
         assert len(hi) == 5
+        assert res.metadata["diagnostics"]["ci"]["available"] is True
+        assert res.metadata["diagnostics"]["ci"]["status"] == "available"
 
     def test_forecast_ci_in_params(self):
         m = GenericSktimeMethod()
@@ -271,6 +270,36 @@ class TestSktimeMethodForecast:
             m = GenericSktimeMethod()
             res = m.forecast(_series(), horizon=5, seasonality=12, params={"ci_alpha": 0.1})
             assert res.ci_values is None
+            assert res.metadata["diagnostics"]["ci"]["available"] is False
+            assert res.metadata["diagnostics"]["ci"]["status"] == "error"
+            assert res.metadata["diagnostics"]["ci"]["error_type"] == "RuntimeError"
+        finally:
+            _FakeThetaForecaster.predict_interval = orig
+
+    def test_forecast_ci_missing_interval_columns_sets_diagnostics(self):
+        orig = _FakeThetaForecaster.predict_interval
+
+        def _mismatched_intervals(self, fh, X=None, coverage=0.9):
+            h = len(fh)
+            idx = pd.RangeIndex(h)
+            cols = pd.MultiIndex.from_tuples([
+                ("y", 0.8, "lower"),
+                ("y", 0.8, "upper"),
+            ])
+            data = np.column_stack([np.ones(h) * 40.0, np.ones(h) * 44.0])
+            return pd.DataFrame(data, index=idx, columns=cols)
+
+        _FakeThetaForecaster.predict_interval = _mismatched_intervals
+        try:
+            m = GenericSktimeMethod()
+            res = m.forecast(_series(), horizon=5, seasonality=12, params={"ci_alpha": 0.1})
+            assert res.ci_values is None
+            assert res.metadata["diagnostics"]["ci"]["available"] is False
+            assert res.metadata["diagnostics"]["ci"]["status"] == "unavailable"
+            assert res.metadata["diagnostics"]["ci"]["interval_columns"] == [
+                "('y', 0.8, 'lower')",
+                "('y', 0.8, 'upper')",
+            ]
         finally:
             _FakeThetaForecaster.predict_interval = orig
 

--- a/tests/forecast/test_statsforecast_method_business_logic.py
+++ b/tests/forecast/test_statsforecast_method_business_logic.py
@@ -55,3 +55,41 @@ def test_statsforecast_forecast_requires_unique_id_rows(monkeypatch):
 
     with pytest.raises(RuntimeError, match="StatsForecast dummy_stats error: StatsForecast output missing unique_id column"):
         _DummyStatsMethod().forecast(pd.Series([1.0, 2.0, 3.0]), horizon=1, seasonality=1, params={})
+
+
+def test_statsforecast_forecast_records_ci_diagnostics_when_columns_missing(monkeypatch):
+    class FakeStatsForecast:
+        def __init__(self, models, freq):
+            pass
+
+        def fit(self, Y_df, X_df=None):
+            return None
+
+        def predict(self, h, X_df=None, level=None):
+            return pd.DataFrame(
+                {
+                    "unique_id": ["ts"],
+                    "dummy_stats": [1.0],
+                }
+            )
+
+    fake_stats_mod = ModuleType("statsforecast")
+    fake_stats_mod.StatsForecast = FakeStatsForecast
+    monkeypatch.setitem(sys.modules, "statsforecast", fake_stats_mod)
+    monkeypatch.setattr(
+        common_mod,
+        "_create_training_dataframes",
+        lambda *args, **kwargs: (pd.DataFrame({"y": [1.0]}), None, None),
+    )
+    monkeypatch.setattr(
+        common_mod,
+        "_extract_forecast_values",
+        lambda *args, **kwargs: pd.Series([1.0]).to_numpy(),
+    )
+
+    res = _DummyStatsMethod().forecast(pd.Series([1.0, 2.0, 3.0]), horizon=1, seasonality=1, params={}, ci_alpha=0.05)
+
+    assert res.ci_values is None
+    assert res.metadata["diagnostics"]["ci"]["available"] is False
+    assert res.metadata["diagnostics"]["ci"]["status"] == "unavailable"
+    assert res.metadata["diagnostics"]["ci"]["level"] == 95


### PR DESCRIPTION
## Summary
- resolve code-reports/to-do/issue-19-silent-ci-extraction-failures.md
- stop sktime from swallowing CI extraction failures without any method-level trace
- add matching CI diagnostics when statsforecast receives no interval columns

## Root cause
sktime wrapped the whole interval extraction path in xcept Exception: pass, so direct callers got a point forecast with no metadata explaining why confidence intervals vanished. statsforecast did not swallow exceptions the same way, but it still returned ci_values=None without any diagnostic metadata when the requested interval columns were absent.

## Implemented solution
- added a shared CI diagnostics metadata builder in orecast.common
- updated sktime to log CI extraction failures and return standardized diagnostics for available, unavailable, and error states
- updated statsforecast to emit the same diagnostics when requested interval columns are missing
- added focused regressions for successful CI metadata, exception-based sktime failures, mismatched sktime interval columns, and missing statsforecast interval columns

## Trade-offs / limitations
The public forecast engine response stays unchanged apart from the existing top-level CI warning path; the new detail is carried in nested method metadata/diagnostics for callers that need root-cause visibility.