### PR TITLE
utils: surface denoise availability warnings

### DIFF
--- a/src/mtdata/forecast/forecast_engine.py
+++ b/src/mtdata/forecast/forecast_engine.py
@@ -11,7 +11,11 @@ from ..bootstrap.settings import mt5_config
 from ..shared.constants import TIMEFRAME_MAP, TIMEFRAME_SECONDS
 from ..shared.schema import ForecastMethodLiteral, TimeframeLiteral, DenoiseSpec
 from ..shared.validators import invalid_timeframe_error, unsupported_timeframe_seconds_error
-from ..utils.denoise import _apply_denoise, normalize_denoise_spec as _normalize_denoise_spec
+from ..utils.denoise import (
+    _apply_denoise,
+    _consume_denoise_warnings,
+    normalize_denoise_spec as _normalize_denoise_spec,
+)
 from ..utils.mt5 import get_cached_mt5_time_alignment, get_symbol_info_cached
 from ..utils.utils import (
     _format_time_minimal,
@@ -807,6 +811,7 @@ def forecast_engine(
             return {"error": str(ex)}
         except Exception as ex:
             return {"error": str(ex)}
+        denoise_warnings = _consume_denoise_warnings(df)
 
         # Track last close for potential price reconstruction
         try:
@@ -958,6 +963,15 @@ def forecast_engine(
                     warnings.append(warning_text)
                 if warnings:
                     result["warnings"] = warnings
+        if denoise_warnings:
+            warnings = result.get("warnings")
+            if not isinstance(warnings, list):
+                warnings = []
+            for warning_text in denoise_warnings:
+                if warning_text not in warnings:
+                    warnings.append(warning_text)
+            if warnings:
+                result["warnings"] = warnings
         if method_l == 'ensemble' and metadata:
             result['ensemble'] = metadata
         return result

--- a/src/mtdata/services/data_service.py
+++ b/src/mtdata/services/data_service.py
@@ -26,7 +26,7 @@ from ..shared.validators import invalid_timeframe_error
 # Imports from utils
 from ..utils.mt5 import (
     _mt5_copy_rates_from, _mt5_copy_rates_range,
-    _mt5_copy_ticks_range, _mt5_epoch_to_utc, _rates_to_df, _symbol_ready_guard,
+    _mt5_copy_ticks_range, _rates_to_df, _symbol_ready_guard,
     get_cached_mt5_time_alignment, get_symbol_info_cached, mt5
 )
 from ..utils.utils import (
@@ -41,7 +41,11 @@ from ..utils.indicators import (
     _find_unknown_ta_indicators_util,
     _parse_ti_specs,
 )
-from ..utils.denoise import _apply_denoise as _apply_denoise_util, normalize_denoise_spec as _normalize_denoise_spec
+from ..utils.denoise import (
+    _apply_denoise as _apply_denoise_util,
+    _consume_denoise_warnings,
+    normalize_denoise_spec as _normalize_denoise_spec,
+)
 
 # Simplify entrypoint and helpers.
 from ..utils.simplify import (
@@ -859,8 +863,11 @@ def fetch_candles(
 
         # Track denoise metadata if applied
         denoise_apps: List[Dict[str, Any]] = []
+        denoise_warnings: List[str] = []
         _apply_pre_ti_denoise(df, headers, denoise, denoise_apps)
+        denoise_warnings.extend(_consume_denoise_warnings(df))
         ti_cols = _apply_indicator_stage(df, headers, ti_spec, denoise)
+        denoise_warnings.extend(_consume_denoise_warnings(df))
 
         # Filter out warmup region to return the intended target window only
         df = _trim_df_to_target(df, start_datetime, end_datetime, candles, copy_rows=True)
@@ -903,6 +910,7 @@ def fetch_candles(
                             ti_spec=ti_spec,
                             headers=headers,
                         )
+                        denoise_warnings.extend(_consume_denoise_warnings(df))
                         # Re-trim to target window
                         df = _trim_df_to_target(df, start_datetime, end_datetime, candles, copy_rows=False)
                         rows_after_target_trim = int(len(df))
@@ -911,6 +919,7 @@ def fetch_candles(
 
         # Optional post-TI denoising (adds new columns by default)
         _apply_post_ti_denoise(df, headers, denoise, denoise_apps)
+        denoise_warnings.extend(_consume_denoise_warnings(df))
 
         # Ensure headers are unique and exist in df
         headers = [h for h in headers if h in df.columns]
@@ -1019,6 +1028,14 @@ def fetch_candles(
         # Attach denoise applications metadata if any
         if denoise_apps:
             payload['denoise'] = {'applications': denoise_apps}
+        if denoise_warnings:
+            warns = payload.get('warnings')
+            if not isinstance(warns, list):
+                warns = []
+            for warning_text in denoise_warnings:
+                if warning_text not in warns:
+                    warns.append(warning_text)
+            payload['warnings'] = warns
         if session_gaps:
             payload['session_gaps'] = session_gaps
             warns = payload.get('warnings')

--- a/src/mtdata/utils/denoise/api.py
+++ b/src/mtdata/utils/denoise/api.py
@@ -206,12 +206,12 @@ def _denoise_series(
     if params is None:
         params = {}
     method = (method or 'none').lower().strip()
-    n = len(s)
-    if n < 3:
-        return s
     if method == 'none':
         return s
     handler = _resolve_denoise_handler(method)
+    n = len(s)
+    if n < 3:
+        return s
     return _run_denoise_handler(s, handler, params, causality)
 
 

--- a/src/mtdata/utils/denoise/api.py
+++ b/src/mtdata/utils/denoise/api.py
@@ -52,7 +52,7 @@ try:
 except Exception:
     _VMD = None  # type: ignore
 
-from .base import get_filter, list_filters, _series_like
+from .base import get_filter, list_filters
 from . import filters  # noqa: F401 - registers all filters
 
 _logger = logging.getLogger(__name__)
@@ -124,6 +124,78 @@ _DENOISE_METHOD_SUPPORTS = {
 }
 
 
+def _denoise_availability(name: str) -> tuple[bool, str]:
+    if name == 'wavelet':
+        return (_pywt is not None, 'PyWavelets')
+    if name in ('emd', 'eemd', 'ceemdan'):
+        return (any(x is not None for x in (_EMD, _EEMD, _CEEMDAN)), 'EMD-signal')
+    if name in ('hp', 'whittaker'):
+        return (_sps is not None and _sps_linalg is not None, 'scipy.sparse')
+    if name == 'savgol':
+        return (_savgol_filter is not None, 'scipy.signal')
+    if name == 'butterworth':
+        return (_butter is not None, 'scipy.signal')
+    if name == 'gaussian':
+        return (_gaussian_filter1d is not None, 'scipy.ndimage')
+    if name == 'wavelet_packet':
+        return (_pywt is not None, 'PyWavelets')
+    if name == 'loess':
+        return (_lowess is not None, 'statsmodels')
+    if name == 'stl':
+        return (_STL is not None, 'statsmodels')
+    if name == 'vmd':
+        return (_VMD is not None, 'vmdpy')
+    return (True, '')
+
+
+def _append_denoise_warning(df: pd.DataFrame, message: str) -> None:
+    warning_text = str(message).strip()
+    if not warning_text:
+        return
+    warnings_out = df.attrs.get("denoise_warnings")
+    if not isinstance(warnings_out, list):
+        warnings_out = []
+    if warning_text not in warnings_out:
+        warnings_out.append(warning_text)
+    df.attrs["denoise_warnings"] = warnings_out
+    _logger.warning("%s", warning_text)
+
+
+def _consume_denoise_warnings(df: pd.DataFrame) -> List[str]:
+    warnings_out = df.attrs.get("denoise_warnings")
+    if not isinstance(warnings_out, list):
+        return []
+    cleaned = [str(item).strip() for item in warnings_out if str(item).strip()]
+    df.attrs["denoise_warnings"] = []
+    return cleaned
+
+
+def _resolve_denoise_handler(method: str):
+    handler = get_filter(method)
+    if handler is None:
+        available = sorted(list_filters().keys())
+        raise ValueError(
+            f"Unknown denoise method '{method}'. Available methods: {', '.join(available)}."
+        )
+    available, requires = _denoise_availability(method)
+    if not available:
+        raise RuntimeError(
+            f"Denoise method '{method}' requires {requires}, but it is not installed."
+        )
+    return handler
+
+
+def _run_denoise_handler(
+    s: pd.Series,
+    handler,
+    params: Dict[str, Any],
+    causality: str,
+) -> pd.Series:
+    # Materialize a writable contiguous buffer
+    x = np.array(s.astype(float).ffill().bfill().to_numpy(copy=True), dtype=float, copy=True, order='C')
+    return handler(s, x, params, causality)
+
+
 def _denoise_series(
     s: pd.Series,
     method: str = 'none',
@@ -139,12 +211,8 @@ def _denoise_series(
         return s
     if method == 'none':
         return s
-    handler = get_filter(method)
-    if handler is None:
-        return s
-    # Materialize a writable contiguous buffer
-    x = np.array(s.astype(float).ffill().bfill().to_numpy(copy=True), dtype=float, copy=True, order='C')
-    return handler(s, x, params, causality)
+    handler = _resolve_denoise_handler(method)
+    return _run_denoise_handler(s, handler, params, causality)
 
 
 def _apply_denoise(
@@ -189,13 +257,22 @@ def _apply_denoise(
     causality = str(spec.get('causality') or ('causal' if when == 'pre_ti' else 'zero_phase'))
     keep_original = bool(spec.get('keep_original')) if 'keep_original' in spec else (when != 'pre_ti')
     suffix = str(spec.get('suffix') or '_dn')
+    try:
+        handler = _resolve_denoise_handler(method)
+    except Exception as ex:
+        _append_denoise_warning(df, str(ex))
+        return added_cols
 
     for col in cols:
         if col not in df.columns:
             continue
         try:
-            y = _denoise_series(df[col], method=method, params=params, causality=causality)
-        except Exception:
+            y = _run_denoise_handler(df[col], handler, params, causality)
+        except Exception as ex:
+            _append_denoise_warning(
+                df,
+                f"Denoise method '{method}' failed on column '{col}': {ex}",
+            )
             continue
         if keep_original:
             new_col = f"{col}{suffix}"
@@ -220,8 +297,11 @@ def _resolve_denoise_base_col(
         added = _apply_denoise(df, denoise, default_when=default_when)
         if f"{base_col}_dn" in added:
             return f"{base_col}_dn"
-    except Exception:
-        pass
+    except Exception as ex:
+        _append_denoise_warning(
+            df,
+            f"Denoise request for base column '{base_col}' failed: {ex}",
+        )
     return base_col
 
 
@@ -254,9 +334,7 @@ def normalize_denoise_spec(spec: Any, default_when: str = 'pre_ti') -> Optional[
         return None
     if method == '' or method == 'none':
         return None
-    params = deepcopy(_DENOISE_METHOD_DEFAULT_PARAMS.get(method))
-    if params is None:
-        return None
+    params = deepcopy(_DENOISE_METHOD_DEFAULT_PARAMS.get(method, {}))
     out = dict(base)
     out.update({"method": method, "params": params})
     return out
@@ -264,29 +342,6 @@ def normalize_denoise_spec(spec: Any, default_when: str = 'pre_ti') -> Optional[
 
 def get_denoise_methods_data() -> Dict[str, Any]:
     """Get metadata about all available denoise methods."""
-    def avail_requires(name: str):
-        if name == 'wavelet':
-            return (_pywt is not None, 'PyWavelets')
-        if name in ('emd', 'eemd', 'ceemdan'):
-            return (any(x is not None for x in (_EMD, _EEMD, _CEEMDAN)), 'EMD-signal')
-        if name in ('hp', 'whittaker'):
-            return (_sps is not None and _sps_linalg is not None, 'scipy.sparse')
-        if name == 'savgol':
-            return (_savgol_filter is not None, 'scipy.signal')
-        if name == 'butterworth':
-            return (_butter is not None, 'scipy.signal')
-        if name == 'gaussian':
-            return (_gaussian_filter1d is not None, 'scipy.ndimage')
-        if name == 'wavelet_packet':
-            return (_pywt is not None, 'PyWavelets')
-        if name == 'loess':
-            return (_lowess is not None, 'statsmodels')
-        if name == 'stl':
-            return (_STL is not None, 'statsmodels')
-        if name == 'vmd':
-            return (_VMD is not None, 'vmdpy')
-        return (True, '')
-
     base_defaults = _denoise_base_defaults("pre_ti")
     methods: List[Dict[str, Any]] = [
         {
@@ -302,7 +357,7 @@ def get_denoise_methods_data() -> Dict[str, Any]:
 
     registry = list_filters()
     for method_name in sorted(registry.keys()):
-        available, requires = avail_requires(method_name)
+        available, requires = _denoise_availability(method_name)
         default_params = _DENOISE_METHOD_DEFAULT_PARAMS.get(method_name, {})
         methods.append({
             "method": method_name,
@@ -331,6 +386,7 @@ def denoise_list_methods() -> Dict[str, Any]:
 __all__ = [
     "_denoise_series",
     "_apply_denoise",
+    "_consume_denoise_warnings",
     "_resolve_denoise_base_col",
     "normalize_denoise_spec",
     "get_denoise_methods_data",

--- a/tests/forecast/test_forecast_engine_business_logic.py
+++ b/tests/forecast/test_forecast_engine_business_logic.py
@@ -492,6 +492,51 @@ def test_forecast_engine_applies_denoise_to_prefetched_raw_history(monkeypatch):
     assert captured["last_value"] == float(df["close"].iloc[-1] * 10.0)
 
 
+def test_forecast_engine_surfaces_denoise_warnings(monkeypatch):
+    class CaptureForecaster:
+        def forecast(self, series, horizon, seasonality, params, exog_future=None, **kwargs):
+            return ForecastResult(
+                forecast=np.array([float(series.iloc[-1])], dtype=float),
+                params_used={},
+                metadata={},
+            )
+
+    class FakeRegistry:
+        @staticmethod
+        def get(name):
+            return CaptureForecaster()
+
+    monkeypatch.setattr(fe, "TIMEFRAME_MAP", {"H1": 1})
+    monkeypatch.setattr(fe, "TIMEFRAME_SECONDS", {"H1": 3600})
+    monkeypatch.setattr(fe, "_get_available_methods", lambda: ("naive",))
+    monkeypatch.setattr(fe, "_parse_kv_or_json", lambda v: dict(v or {}))
+    monkeypatch.setattr(fe, "ForecastRegistry", FakeRegistry)
+    monkeypatch.setattr(fe, "get_symbol_info_cached", lambda symbol: None)
+
+    df = _df(20)
+    df.attrs["denoise_warnings"] = [
+        "Denoise method 'wavelet' requires PyWavelets, but it is not installed."
+    ]
+
+    monkeypatch.setattr(
+        fe,
+        "_resolve_history_context",
+        lambda **kwargs: (df, "close", {"method": "wavelet"}),
+    )
+
+    out = fe.forecast_engine(
+        symbol="EURUSD",
+        timeframe="H1",
+        method="naive",
+        horizon=1,
+        denoise={"method": "wavelet"},
+    )
+
+    assert out["success"] is True
+    assert "warnings" in out
+    assert any("requires PyWavelets" in warning for warning in out["warnings"])
+
+
 def test_forecast_engine_builds_exog_and_aligns_for_returns(monkeypatch):
     captured = {}
 

--- a/tests/services/test_data_service_coverage.py
+++ b/tests/services/test_data_service_coverage.py
@@ -5,15 +5,14 @@ private helpers, data transformation, validation, and error handling.
 """
 
 import unittest
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock
 from contextlib import contextmanager
-from typing import Any, Iterator, Tuple, Optional
+from typing import Any, Iterator, Tuple
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 import sys
 import os
-import math
 
 # Ensure src is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
@@ -22,10 +21,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 _mt5_mock = MagicMock()
 sys.modules['MetaTrader5'] = _mt5_mock
 
-import numpy as np
-import pandas as pd
+import pandas as pd  # noqa: E402
 
-from mtdata.services.data_service import (
+from mtdata.services.data_service import (  # noqa: E402
     _fetch_rates_with_warmup,
     _build_rates_df,
     _trim_df_to_target,
@@ -1152,6 +1150,33 @@ class TestFetchCandles(unittest.TestCase):
         self.assertTrue(result.get('success'))
         if result.get('denoise'):
             self.assertTrue(result['denoise']['applications'])
+
+    @patch(_MT5_CONFIG)
+    @patch(f'{_DS}._normalize_denoise_spec')
+    @patch(_SIMPLIFY_EXT, side_effect=lambda df, h, s: (df, None))
+    @patch(_RATES_FROM)
+    @patch(_CACHED_INFO, return_value=MagicMock())
+    @patch(_RESOLVE_CTZ, return_value=None)
+    @patch(_ESTIMATE_WARMUP, return_value=0)
+    @patch(_GUARD, _mock_symbol_guard)
+    def test_denoise_warning_is_surfaced(self, mock_warmup, mock_ctz, mock_info, mock_from, mock_simp,
+                                         mock_norm_dn, mock_cfg):
+        mock_cfg.get_time_offset_seconds.return_value = 0
+        mock_from.return_value = _make_rates(10)
+        mock_norm_dn.return_value = {'method': 'wavelet', 'when': 'pre_ti', 'params': {}}
+
+        def add_warning(df, spec, **kwargs):
+            df.attrs["denoise_warnings"] = [
+                "Denoise method 'wavelet' requires PyWavelets, but it is not installed."
+            ]
+            return []
+
+        with patch(f'{_DS}._apply_denoise_util', side_effect=add_warning):
+            result = fetch_candles('EURUSD', limit=5, denoise={'method': 'wavelet'})
+
+        self.assertTrue(result.get('success'))
+        self.assertIn('warnings', result)
+        self.assertIn("requires PyWavelets", result['warnings'][0])
 
     # -- Start / End datetime ------------------------------------------------
 

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -228,6 +228,18 @@ class TestDenoiseSeriesDispatch:
         result = _denoise_series(s, method="ema")
         pd.testing.assert_series_equal(result, s)
 
+    def test_short_series_unknown_method_still_raises(self):
+        s = _make_series(np.array([1.0, 2.0]))
+        with pytest.raises(ValueError, match="Unknown denoise method"):
+            _denoise_series(s, method="nonexistent_method")
+
+    def test_short_series_missing_optional_dependency_still_raises(self, monkeypatch):
+        s = _make_series(np.array([1.0, 2.0]))
+        monkeypatch.setattr("mtdata.utils.denoise._pywt", None)
+
+        with pytest.raises(RuntimeError, match="requires PyWavelets"):
+            _denoise_series(s, method="wavelet", params={"wavelet": "db4"})
+
     def test_ema(self):
         s = _make_series(NOISY_SIGNAL)
         result = _denoise_series(s, method="ema", params={"span": 10})

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -1,7 +1,5 @@
 """Comprehensive tests for mtdata.utils.denoise module."""
 
-import math
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -191,7 +189,10 @@ class TestNormalizeDenoiseSec:
         assert normalize_denoise_spec("none") is None
 
     def test_unknown_method_returns_none(self):
-        assert normalize_denoise_spec("nonexistent_filter") is None
+        out = normalize_denoise_spec("nonexistent_filter")
+        assert out is not None
+        assert out["method"] == "nonexistent_filter"
+        assert out["params"] == {}
 
     def test_default_when(self):
         out = normalize_denoise_spec("ema", default_when="post_ti")
@@ -328,13 +329,13 @@ class TestDenoiseSeriesDispatch:
         _check_basic(result.values, N)
 
     def test_wavelet(self):
-        pywt = pytest.importorskip("pywt")
+        pytest.importorskip("pywt")
         s = _make_series(NOISY_SIGNAL)
         result = _denoise_series(s, method="wavelet", params={"wavelet": "db4"})
         _check_basic(result.values, N)
 
     def test_wavelet_packet(self):
-        pywt = pytest.importorskip("pywt")
+        pytest.importorskip("pywt")
         s = _make_series(NOISY_SIGNAL)
         result = _denoise_series(s, method="wavelet_packet", params={"wavelet": "db4"})
         _check_basic(result.values, N)
@@ -410,8 +411,15 @@ class TestDenoiseSeriesDispatch:
 
     def test_unknown_method_returns_identity(self):
         s = _make_series(NOISY_SIGNAL)
-        result = _denoise_series(s, method="nonexistent_method")
-        pd.testing.assert_series_equal(result, s)
+        with pytest.raises(ValueError, match="Unknown denoise method"):
+            _denoise_series(s, method="nonexistent_method")
+
+    def test_missing_optional_dependency_raises_clear_error(self, monkeypatch):
+        s = _make_series(NOISY_SIGNAL)
+        monkeypatch.setattr("mtdata.utils.denoise._pywt", None)
+
+        with pytest.raises(RuntimeError, match="requires PyWavelets"):
+            _denoise_series(s, method="wavelet", params={"wavelet": "db4"})
 
     def test_ema_causal(self):
         s = _make_series(NOISY_SIGNAL)
@@ -508,6 +516,17 @@ class TestApplyDenoise:
         spec = {"method": "sma", "params": {"window": 5}, "columns": "all", "keep_original": True}
         added = _apply_denoise(df, spec)
         assert len(added) >= 4
+
+    def test_unknown_method_records_warning_and_returns_raw_data(self):
+        df = self._make_df()
+        original = df["close"].copy()
+
+        added = _apply_denoise(df, {"method": "nonexistent_method", "columns": ["close"], "keep_original": False})
+
+        assert added == []
+        pd.testing.assert_series_equal(df["close"], original)
+        assert "denoise_warnings" in df.attrs
+        assert "Unknown denoise method 'nonexistent_method'" in df.attrs["denoise_warnings"][0]
 
 
 # ======================================================================


### PR DESCRIPTION
## Summary
- resolve `code-reports/to-do/issue-21-denoise-package-checks.md`
- stop unavailable or unknown denoise methods from silently acting like a no-op
- surface denoise warnings through the candle and forecast responses that already carry warning text

## Root cause
The denoise stack had a silent failure chain: `get_filter()` could miss, `_denoise_series()` returned the original series unchanged, and `_apply_denoise()` swallowed per-column failures with `continue`. Availability metadata already existed for `denoise_list_methods()`, but execution never consulted it.

## Implemented solution
- extracted shared denoise availability checks in `utils.denoise.api`
- made `_denoise_series()` raise clear errors for unknown methods and missing optional dependencies
- kept `_apply_denoise()` non-fatal, but converted those failures into recorded warnings instead of silent fallbacks
- surfaced recorded denoise warnings in `fetch_candles()` and `forecast_engine()` responses
- added focused regressions for direct utility errors, DataFrame warning capture, and warning propagation into service/forecast outputs

## Trade-offs / limitations
The endpoints still return raw data when denoising cannot run, but they no longer do so silently. This keeps the existing graceful-degradation behavior while making the failure visible to callers.