### PR TITLE
trading: share SL/TP normalization

### DIFF
--- a/src/mtdata/core/trading_execution.py
+++ b/src/mtdata/core/trading_execution.py
@@ -11,16 +11,6 @@ from .trading_gateway import MT5TradingGateway, create_trading_gateway, trading_
 from .trading_positions import _resolve_open_position
 from .trading_time import ExpirationValue
 from ..utils.mt5 import _mt5_epoch_to_utc
-from ..utils.mt5 import ensure_mt5_connection_or_raise
-
-def _zero_price_requested(value: Optional[Union[int, float]]) -> bool:
-    if value is None or isinstance(value, bool):
-        return False
-    try:
-        numeric = float(value)
-    except Exception:
-        return False
-    return math.isfinite(numeric) and math.isclose(numeric, 0.0, abs_tol=1e-9)
 
 
 def _resolve_position_side(position: Any, mt5: Any) -> Optional[str]:
@@ -148,22 +138,26 @@ def _modify_position(
             point = float(symbol_info.point or 0.0) if hasattr(symbol_info, "point") else 0.0
             digits = trading_validation._safe_int_attr(symbol_info, "digits", 5)
 
-            explicit_remove_sl = _zero_price_requested(stop_loss)
-            explicit_remove_tp = _zero_price_requested(take_profit)
-            requested_sl = (
-                None
-                if stop_loss is None or explicit_remove_sl
-                else trading_validation._normalize_price_for_symbol(stop_loss, point=point, digits=digits)
+            requested_sl, explicit_remove_sl, sl_error = (
+                trading_validation._normalize_requested_protection_price(
+                    stop_loss,
+                    field_name="stop_loss",
+                    point=point,
+                    digits=digits,
+                )
             )
-            requested_tp = (
-                None
-                if take_profit is None or explicit_remove_tp
-                else trading_validation._normalize_price_for_symbol(take_profit, point=point, digits=digits)
+            if sl_error is not None:
+                return {"error": sl_error}
+            requested_tp, explicit_remove_tp, tp_error = (
+                trading_validation._normalize_requested_protection_price(
+                    take_profit,
+                    field_name="take_profit",
+                    point=point,
+                    digits=digits,
+                )
             )
-            if stop_loss is not None and not explicit_remove_sl and requested_sl is None:
-                return {"error": "stop_loss must be a non-zero finite price after symbol normalization."}
-            if take_profit is not None and not explicit_remove_tp and requested_tp is None:
-                return {"error": "take_profit must be a non-zero finite price after symbol normalization."}
+            if tp_error is not None:
+                return {"error": tp_error}
 
             # Normalize SL/TP values
             existing_sl = trading_validation._normalize_price_for_symbol(
@@ -381,8 +375,6 @@ def _modify_pending_order(
             point = float(getattr(symbol_info, "point", 0.0) or 0.0)
             digits = trading_validation._safe_int_attr(symbol_info, "digits", 5)
 
-            explicit_remove_sl = _zero_price_requested(stop_loss)
-            explicit_remove_tp = _zero_price_requested(take_profit)
             normalized_price = trading_validation._normalize_price_for_symbol(
                 price if price is not None else getattr(order, "price_open", None),
                 point=point,
@@ -390,21 +382,26 @@ def _modify_pending_order(
             )
             if normalized_price is None:
                 return {"error": "price must be a non-zero finite number after symbol normalization."}
-
-            requested_sl = (
-                None
-                if stop_loss is None or explicit_remove_sl
-                else trading_validation._normalize_price_for_symbol(stop_loss, point=point, digits=digits)
+            requested_sl, explicit_remove_sl, sl_error = (
+                trading_validation._normalize_requested_protection_price(
+                    stop_loss,
+                    field_name="stop_loss",
+                    point=point,
+                    digits=digits,
+                )
             )
-            requested_tp = (
-                None
-                if take_profit is None or explicit_remove_tp
-                else trading_validation._normalize_price_for_symbol(take_profit, point=point, digits=digits)
+            if sl_error is not None:
+                return {"error": sl_error}
+            requested_tp, explicit_remove_tp, tp_error = (
+                trading_validation._normalize_requested_protection_price(
+                    take_profit,
+                    field_name="take_profit",
+                    point=point,
+                    digits=digits,
+                )
             )
-            if stop_loss is not None and not explicit_remove_sl and requested_sl is None:
-                return {"error": "stop_loss must be a non-zero finite price after symbol normalization."}
-            if take_profit is not None and not explicit_remove_tp and requested_tp is None:
-                return {"error": "take_profit must be a non-zero finite price after symbol normalization."}
+            if tp_error is not None:
+                return {"error": tp_error}
 
             existing_sl = trading_validation._normalize_price_for_symbol(
                 getattr(order, "sl", None),

--- a/src/mtdata/core/trading_orders.py
+++ b/src/mtdata/core/trading_orders.py
@@ -204,20 +204,26 @@ def _place_market_order(
             point = float(symbol_info.point or 0.0) if hasattr(symbol_info, "point") else 0.0
             digits = trading_validation._safe_int_attr(symbol_info, "digits", 5)
 
-            norm_sl = (
-                trading_validation._normalize_price_for_symbol(stop_loss, point=point, digits=digits)
-                if stop_loss not in (None, 0)
-                else None
+            norm_sl, _explicit_remove_sl, sl_error = (
+                trading_validation._normalize_requested_protection_price(
+                    stop_loss,
+                    field_name="stop_loss",
+                    point=point,
+                    digits=digits,
+                )
             )
-            norm_tp = (
-                trading_validation._normalize_price_for_symbol(take_profit, point=point, digits=digits)
-                if take_profit not in (None, 0)
-                else None
+            if sl_error is not None:
+                return {"error": sl_error}
+            norm_tp, _explicit_remove_tp, tp_error = (
+                trading_validation._normalize_requested_protection_price(
+                    take_profit,
+                    field_name="take_profit",
+                    point=point,
+                    digits=digits,
+                )
             )
-            if stop_loss not in (None, 0) and norm_sl is None:
-                return {"error": "stop_loss must be a non-zero finite price after symbol normalization."}
-            if take_profit not in (None, 0) and norm_tp is None:
-                return {"error": "take_profit must be a non-zero finite price after symbol normalization."}
+            if tp_error is not None:
+                return {"error": tp_error}
 
             # Validate against a recent quote, then refresh again right before send.
             validate_tick = mt5.symbol_info_tick(symbol)
@@ -687,20 +693,26 @@ def _place_pending_order(
             norm_price = trading_validation._normalize_price_for_symbol(price, point=point, digits=digits)
             if norm_price is None:
                 return {"error": "price must be a non-zero finite number after symbol normalization."}
-            norm_sl = (
-                trading_validation._normalize_price_for_symbol(stop_loss, point=point, digits=digits)
-                if stop_loss not in (None, 0)
-                else None
+            norm_sl, _explicit_remove_sl, sl_error = (
+                trading_validation._normalize_requested_protection_price(
+                    stop_loss,
+                    field_name="stop_loss",
+                    point=point,
+                    digits=digits,
+                )
             )
-            norm_tp = (
-                trading_validation._normalize_price_for_symbol(take_profit, point=point, digits=digits)
-                if take_profit not in (None, 0)
-                else None
+            if sl_error is not None:
+                return {"error": sl_error}
+            norm_tp, _explicit_remove_tp, tp_error = (
+                trading_validation._normalize_requested_protection_price(
+                    take_profit,
+                    field_name="take_profit",
+                    point=point,
+                    digits=digits,
+                )
             )
-            if stop_loss not in (None, 0) and norm_sl is None:
-                return {"error": "stop_loss must be a non-zero finite price after symbol normalization."}
-            if take_profit not in (None, 0) and norm_tp is None:
-                return {"error": "take_profit must be a non-zero finite price after symbol normalization."}
+            if tp_error is not None:
+                return {"error": tp_error}
 
             normalized_expiration, expiration_specified = trading_time._normalize_pending_expiration(expiration)
             live_tick = mt5.symbol_info_tick(symbol) or initial_tick

--- a/src/mtdata/core/trading_validation.py
+++ b/src/mtdata/core/trading_validation.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 from .trading_gateway import MT5TradingGateway, create_trading_gateway, trading_connection_error
 from ..utils.utils import _coerce_finite_float, _coerce_scalar
-from ..utils.mt5 import ensure_mt5_connection_or_raise
 
 
 MarketOrderTypeLiteral = Literal["BUY", "SELL"]
@@ -219,6 +218,32 @@ def _normalize_price_for_symbol(
     if not math.isfinite(numeric) or numeric == 0.0:
         return None
     return float(numeric)
+
+
+def _zero_price_requested(value: Optional[Union[int, float]]) -> bool:
+    if value is None or isinstance(value, bool):
+        return False
+    try:
+        numeric = float(value)
+    except Exception:
+        return False
+    return math.isfinite(numeric) and math.isclose(numeric, 0.0, abs_tol=1e-9)
+
+
+def _normalize_requested_protection_price(
+    value: Optional[Union[int, float]],
+    *,
+    field_name: str,
+    point: float,
+    digits: int,
+) -> Tuple[Optional[float], bool, Optional[str]]:
+    explicit_remove = _zero_price_requested(value)
+    if value is None or explicit_remove:
+        return None, explicit_remove, None
+    normalized = _normalize_price_for_symbol(value, point=point, digits=digits)
+    if normalized is None:
+        return None, explicit_remove, f"{field_name} must be a non-zero finite price after symbol normalization."
+    return float(normalized), explicit_remove, None
 
 
 def _broker_distance_metadata(symbol_info: Any) -> Dict[str, float]:

--- a/tests/trading/test_trading_execution.py
+++ b/tests/trading/test_trading_execution.py
@@ -114,6 +114,19 @@ def test_place_market_order_success(mock_mt5):
     assert sltp_req["position"] == 456  # Matching the 'order' ticket from the mock result
 
 
+def test_place_market_order_treats_tiny_zero_stop_loss_as_omitted(mock_mt5):
+    res = _place_market_order(
+        symbol="EURUSD",
+        volume=0.1,
+        order_type="BUY",
+        stop_loss=1e-12,
+    )
+
+    assert "error" not in res
+    assert res["sl_tp_result"]["status"] == "not_requested"
+    assert mock_mt5.order_send.call_count == 1
+
+
 def test_place_market_order_invalid_type(mock_mt5):
     res = _place_market_order(
         symbol="EURUSD",
@@ -244,6 +257,21 @@ def test_place_pending_order_success(mock_mt5):
     assert math.isclose(req["price"], 1.04000)
     assert math.isclose(req["sl"], 1.03000)
     assert math.isclose(req["tp"], 1.06000)
+
+
+def test_place_pending_order_treats_tiny_zero_stop_loss_as_omitted(mock_mt5):
+    res = _place_pending_order(
+        symbol="EURUSD",
+        volume=0.1,
+        order_type="BUY_LIMIT",
+        price=1.04000,
+        stop_loss=1e-12,
+    )
+
+    assert "error" not in res
+    req = mock_mt5.order_send.call_args[0][0]
+    assert math.isclose(req["sl"], 0.0)
+    assert math.isclose(req["tp"], 0.0)
 
 
 def test_place_pending_order_bad_side(mock_mt5):


### PR DESCRIPTION
## Summary
- refactor duplicated SL/TP request normalization into `trading_validation`
- reuse the helper from market and pending order placement plus modify-position and modify-order flows
- cover tiny-zero stop-loss inputs so placement matches the modify/remove semantics

## Root cause
The same SL/TP normalization and error-handling block lived in four trading paths. The order-placement copies had already drifted from the modify flows by treating only literal `0` as removal, while the modify flows used `_zero_price_requested()` and accepted near-zero removal requests.

## Implemented solution
- add `trading_validation._zero_price_requested()` and `_normalize_requested_protection_price()`
- replace the duplicated normalization blocks in `trading_execution.py` and `trading_orders.py`
- add regressions proving market and pending placement omit tiny-zero stop-loss requests instead of rejecting them

## Trade-offs / limitations
- this keeps the rest of the trading validation flow unchanged; it only centralizes protection-price normalization and explicit-zero removal handling

## Report
- `code-reports/to-do/refactoring-sl-tp-normalization-duplicated.md`