### PR TITLE
packaging: separate git-backed install extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,17 @@ It runs as a **Model Context Protocol (MCP)** server or a standalone **CLI**.
 
 ## Quick Start
 
-**Prerequisites:** Windows + Python 3.14 + MetaTrader 5 installed and running (demo account recommended).
+**Prerequisites:** Windows + Python 3.14 + MetaTrader 5 installed and running (demo account recommended). For the full install on Windows, also install Visual Studio Build Tools 2022 with the **Desktop development with C++** workload.
 
 ```bash
+# Optional but recommended: create an isolated conda environment first
+conda create -n mtdata python=3.14 -y
+conda activate mtdata
+
 # Lean core install
 pip install -e .
 
-# Full research/web install
+# Full stable research/web install
 pip install -r requirements.txt
 
 # Verify MT5 connection (lists symbols from the running terminal)
@@ -66,7 +70,9 @@ mtdata-cli forecast_generate EURUSD --timeframe H1 --horizon 12 --method theta
 
 Notes:
 - `pip install -e .` now installs the lean core package only.
-- `pip install -r requirements.txt` installs the full validated Python 3.14 stack, including Chronos/TimesFM, StatsForecast, sktime, mlforecast, and the Web API.
+- `pip install -r requirements.txt` installs the validated Python 3.14 stack from package-index releases, including Chronos, StatsForecast, sktime, mlforecast, news embeddings, and the Web API.
+- Conda is a supported way to isolate the install before running the pip commands above.
+- Git-backed add-ons stay explicit: `pip install -e .[forecast-timesfm]` for TimesFM, `pip install -e .[patterns-ext]` for `precise-patterns`, `pip install -e .[news-ycnbc]` for the CNBC adapter, or `pip install -e .[all-git]` for everything in one go.
 - `gluonts`/Lag-Llama, `hnswlib`, and `tsdownsample` are intentionally excluded from the default 3.14 environment because current wheel support is incomplete or incompatible.
 
 ## Documentation

--- a/docs/FORECAST.md
+++ b/docs/FORECAST.md
@@ -103,7 +103,7 @@ mtdata-cli forecast_generate EURUSD --timeframe H1 --horizon 24 \
   --library pretrained --method timesfm
 ```
 
-*Requires: `pip install torch` plus a TimesFM install (see `requirements.txt`).*
+*Requires: `pip install -e .[forecast-timesfm]`.*
 
 **Lag-Llama** — Foundation model via GluonTS.
 ```bash

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -17,12 +17,25 @@ Installation and configuration guide for mtdata.
 - **Operating System:** Windows (required for MetaTrader 5)
 - **Python:** 3.14
 - **MetaTrader 5:** Installed and running
+- **Windows Build Tools:** Visual Studio Build Tools 2022 with the **Desktop development with C++** workload for `pip install -r requirements.txt` and any Git-backed extras
 
 ---
 
 ## Installation
 
-### 1. Install the Lean Core Package
+### 1. Create an Isolated Conda Environment (Optional but Recommended)
+
+If you use Conda/Miniconda, start with a clean Python 3.14 environment:
+
+```bash
+conda create -n mtdata python=3.14 -y
+conda activate mtdata
+python --version
+```
+
+If you prefer not to use conda, make sure the active interpreter is Python 3.14 before continuing.
+
+### 2. Install the Lean Core Package
 
 From the repository root:
 
@@ -30,32 +43,40 @@ From the repository root:
 pip install -e .
 ```
 
-### 2. Install the Full Feature Set (Optional)
+### 3. Install the Full Stable Feature Set (Optional)
 
-For the validated all-features environment used in local development and docs/examples:
+For the validated research/web environment used in local development and docs/examples:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-### 3. Optional Dependencies
+This path intentionally stays on package-index releases. Git-backed add-ons such as TimesFM, `precise-patterns`, and `ycnbc` stay opt-in so the default install does not depend on Git checkouts.
+
+### 4. Optional Dependencies
 
 The base package is intentionally lean. Install extras as needed:
 
+> Windows note: install Visual Studio Build Tools 2022 with the **Desktop development with C++** workload before the full install or any Git-backed extra. Several optional dependencies include native extensions, and pip may need MSVC when a compatible wheel is unavailable. Git-backed extras also require Git on `PATH`.
+
 - Classical forecasting / optimization:
   `pip install -e .[forecast-classical]`
-- Foundation-model forecasting:
+- Foundation-model forecasting (Chronos / Chronos-Bolt):
   `pip install -e .[forecast-foundation]`
+- TimesFM (Git-backed):
+  `pip install -e .[forecast-timesfm]`
 - Web API:
   `pip install -e .[web]`
-- Experimental pattern engines:
+- Experimental pattern engines (Git-backed):
   `pip install -e .[patterns-ext]`
 - News embeddings (semantic reranking):
   `pip install -e .[news-embeddings]`
-- CNBC news source:
+- CNBC news source (Git-backed):
   `pip install -e .[news-ycnbc]`
-- Everything:
+- Everything from package indexes:
   `pip install -e .[all]`
+- Everything including Git-backed extras:
+  `pip install -e .[all-git]`
 
 Feature notes:
 
@@ -64,7 +85,7 @@ Feature notes:
 - Dimred UMAP (Web UI / analysis): `umap-learn`
 - Foundation models:
   - Chronos (`chronos2`, `chronos_bolt`): `chronos-forecasting`, `torch`
-  - TimesFM (`timesfm`): `timesfm`, `torch` (installed from Git in `requirements.txt`)
+  - TimesFM (`timesfm`): `timesfm`, `torch` (install with `pip install -e .[forecast-timesfm]`; Git-backed extra)
   - Lag-Llama (`lag_llama`): not included in the default Python 3.14 environment because `gluonts`/Lag-Llama are still constrained by upstream compatibility
 - Forecasting libraries: `statsforecast`, `sktime`, `mlforecast` (plus `lightgbm` for GBMs)
 - Volatility (GARCH/ARCH): `arch`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -100,6 +100,9 @@ mtdata-cli forecast_list_methods --json
 ```
 
 Look for `available: false` and the `requires` field. Install missing packages:
+
+If you're installing mtdata extras, run the extra commands below from the repository root.
+
 ```bash
 pip install chronos-forecasting torch  # For Chronos
 pip install statsforecast              # For StatsForecast models
@@ -112,7 +115,7 @@ pip install QuantLib                   # For barrier option pricing & Heston cal
 pip install optuna                     # For Bayesian hyperparameter tuning
 pip install neuralforecast torch       # For NHiTS, TFT, PatchTST, NBEATSx
 pip install finvizfinance              # For fundamental data, screening, insider activity
-pip install -e .[forecast-timesfm]     # For TimesFM (Git-backed extra)
+pip install -e .[forecast-timesfm]     # From the repo root; installs the TimesFM Git-backed extra
 # Lag-Llama may require a separate Python env due to upstream pins (see `requirements.txt`).
 ```
 
@@ -274,7 +277,7 @@ MTDATA_CLI_DEBUG=1 mtdata-cli forecast_generate EURUSD --horizon 12
    ```bash
    pip install -r requirements.txt
    ```
-4. Retry only the extra you need:
+4. From the repository root, retry only the extra you need:
    ```bash
    pip install -e .[forecast-timesfm]
    pip install -e .[patterns-ext]

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -112,7 +112,7 @@ pip install QuantLib                   # For barrier option pricing & Heston cal
 pip install optuna                     # For Bayesian hyperparameter tuning
 pip install neuralforecast torch       # For NHiTS, TFT, PatchTST, NBEATSx
 pip install finvizfinance              # For fundamental data, screening, insider activity
-# TimesFM is installed from Git (pinned in `requirements.txt`); re-run `pip install -r requirements.txt`.
+pip install -e .[forecast-timesfm]     # For TimesFM (Git-backed extra)
 # Lag-Llama may require a separate Python env due to upstream pins (see `requirements.txt`).
 ```
 
@@ -262,6 +262,26 @@ MTDATA_CLI_DEBUG=1 mtdata-cli forecast_generate EURUSD --horizon 12
 ---
 
 ## Optional Dependency Issues
+
+### Git-backed Extra Fails to Install
+
+**Symptom:** `pip install -e .[forecast-timesfm]`, `pip install -e .[patterns-ext]`, or `pip install -e .[news-ycnbc]` fails during clone/build on Windows.
+
+**Solution:**
+1. Install Visual Studio Build Tools 2022 with the **Desktop development with C++** workload.
+2. Make sure Git is installed and available on `PATH`.
+3. Install the stable base stack first:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Retry only the extra you need:
+   ```bash
+   pip install -e .[forecast-timesfm]
+   pip install -e .[patterns-ext]
+   pip install -e .[news-ycnbc]
+   ```
+
+If a Git-backed extra still fails, leave it out and use the rest of mtdata without that integration. For pretrained forecasts, `chronos2` and `chronos_bolt` remain available from the stable install path.
 
 ### QuantLib Import Error
 

--- a/docs/forecast/FORECAST_GENERATE.md
+++ b/docs/forecast/FORECAST_GENERATE.md
@@ -157,7 +157,7 @@ Tip: `mtdata-cli forecast_list_library_models pretrained` shows requirements for
 
 **Dependencies (by model):**
 - `chronos2` / `chronos_bolt`: `chronos-forecasting`, `torch`
-- `timesfm`: `timesfm`, `torch` (TimesFM is installed from Git in `requirements.txt`)
+- `timesfm`: `timesfm`, `torch` (install with `pip install -e .[forecast-timesfm]`)
 - `lag_llama`: `lag-llama`, `gluonts[torch]`, `torch` (may not be installable on all Python versions due to upstream pins)
 
 **Parameters:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ news-embeddings = [
     "huggingface-hub>=0.36.2,<1",
 ]
 news-ycnbc = [
-    "ycnbc @ git+https://github.com/codestorm-official/ycnbc.git@master",
+    "ycnbc @ git+https://github.com/codestorm-official/ycnbc.git@d5e50293be499b617edaa10a03467b4184193a4e",
 ]
 all = [
     "arch>=8.0.0",
@@ -142,7 +142,7 @@ all-git = [
     "fastapi>=0.134.0",
     "uvicorn[standard]>=0.41.0",
     "sentence-transformers>=5.1.2,<6",
-    "ycnbc @ git+https://github.com/codestorm-official/ycnbc.git@master",
+    "ycnbc @ git+https://github.com/codestorm-official/ycnbc.git@d5e50293be499b617edaa10a03467b4184193a4e",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ forecast-foundation = [
     "chronos-forecasting>=2.2.2",
     "transformers>=4.57.6,<5",
     "huggingface-hub>=0.36.2,<1",
+]
+forecast-timesfm = [
+    "torch>=2.10.0",
     "timesfm @ git+https://github.com/google-research/timesfm.git@6bd8044275f8b76cdc9554f2fecccac5f31a156c",
 ]
 patterns-ext = [
@@ -110,12 +113,35 @@ all = [
     "chronos-forecasting>=2.2.2",
     "transformers>=4.57.6,<5",
     "huggingface-hub>=0.36.2,<1",
+    "fastapi>=0.134.0",
+    "uvicorn[standard]>=0.41.0",
+    "sentence-transformers>=5.1.2,<6",
+]
+all-git = [
+    "arch>=8.0.0",
+    "hmmlearn>=0.3.3",
+    "optuna>=4.6.0",
+    "QuantLib>=1.41",
+    "statsforecast==1.7.6",
+    "sktime==0.40.1",
+    "mlforecast==1.0.3",
+    "lightgbm>=4.6.0",
+    "coreforecast>=0.0.17",
+    "fugue>=0.9.7",
+    "numba>=0.64.0",
+    "tsfresh>=0.21.1",
+    "torch>=2.10.0",
+    "torchvision>=0.25.0",
+    "pillow>=12.1.1",
+    "accelerate>=1.12.0",
+    "chronos-forecasting>=2.2.2",
+    "transformers>=4.57.6,<5",
+    "huggingface-hub>=0.36.2,<1",
     "timesfm @ git+https://github.com/google-research/timesfm.git@6bd8044275f8b76cdc9554f2fecccac5f31a156c",
     "precise-patterns @ git+https://github.com/BennyThadikaran/precise-patterns.git@e92e10cbb1b6e414c89ad287be32ddae4214b353",
     "fastapi>=0.134.0",
     "uvicorn[standard]>=0.41.0",
     "sentence-transformers>=5.1.2,<6",
-    "huggingface-hub>=0.36.2,<1",
     "ycnbc @ git+https://github.com/codestorm-official/ycnbc.git@master",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-# Full-feature local/dev install for Python 3.14.
+# Full-feature local/dev install for Python 3.14 using package-index releases only.
 # The base package is intentionally leaner; use this file when you want
-# forecasting libraries, foundation models, pattern adapters, and the Web API.
+# the validated research/web stack without Git-backed extras.
+# Optional Git-backed add-ons (TimesFM, precise-patterns, ycnbc) are documented in docs/SETUP.md.
 
 -e .[all]


### PR DESCRIPTION
## Summary
- keep \\pip install -r requirements.txt\\ on the stable package-index install path
- move TimesFM and other Git-backed integrations to explicit opt-in extras
- document the Visual Studio Build Tools and conda environment setup flow

Closes #1