### PR TITLE
services: avoid in-place rate time shifting

### DIFF
--- a/src/mtdata/services/data_service.py
+++ b/src/mtdata/services/data_service.py
@@ -264,15 +264,17 @@ def _shift_rate_times(rates: Any, shift_seconds: int) -> Any:
         return shifted_rates
 
     if isinstance(rates, list):
+        if not any(isinstance(row, dict) and "time" in row for row in rates):
+            return rates
         shifted_rows = []
         for row in rates:
             if not isinstance(row, dict):
                 shifted_rows.append(row)
                 continue
-            shifted_row = dict(row)
-            if "time" not in shifted_row:
-                shifted_rows.append(shifted_row)
+            if "time" not in row:
+                shifted_rows.append(row)
                 continue
+            shifted_row = dict(row)
             try:
                 shifted_row["time"] = float(shifted_row["time"]) + shift_value
             except Exception:

--- a/src/mtdata/services/data_service.py
+++ b/src/mtdata/services/data_service.py
@@ -256,20 +256,29 @@ def _shift_rate_times(rates: Any, shift_seconds: int) -> Any:
 
     if names and "time" in names:
         try:
-            for idx in range(len(rates)):
-                rates[idx]["time"] = float(rates[idx]["time"]) + shift_value
+            shifted_rates = rates.copy()
+            for idx in range(len(shifted_rates)):
+                shifted_rates[idx]["time"] = float(shifted_rates[idx]["time"]) + shift_value
         except Exception:
-            pass
-        return rates
+            return rates
+        return shifted_rates
 
     if isinstance(rates, list):
+        shifted_rows = []
         for row in rates:
-            if not isinstance(row, dict) or "time" not in row:
+            if not isinstance(row, dict):
+                shifted_rows.append(row)
+                continue
+            shifted_row = dict(row)
+            if "time" not in shifted_row:
+                shifted_rows.append(shifted_row)
                 continue
             try:
-                row["time"] = float(row["time"]) + shift_value
+                shifted_row["time"] = float(shifted_row["time"]) + shift_value
             except Exception:
-                continue
+                pass
+            shifted_rows.append(shifted_row)
+        return shifted_rows
     return rates
 
 

--- a/tests/services/test_data_service_coverage.py
+++ b/tests/services/test_data_service_coverage.py
@@ -142,6 +142,46 @@ class TestShiftRateTimes(unittest.TestCase):
         )
         np.testing.assert_array_equal(shifted['close'], rates['close'])
 
+    def test_list_without_time_keys_returns_original_input(self):
+        rates = [{'close': 1.1}, {'open': 1.2}, 'passthrough']
+
+        shifted = _shift_rate_times(rates, 60)
+
+        self.assertIs(shifted, rates)
+
+    def test_list_with_non_numeric_time_returns_shifted_copy_and_leaves_failing_row_unshifted(self):
+        rates = [
+            {'time': 1704067200.0, 'close': 1.1},
+            {'time': 'not-a-number', 'close': 1.2},
+            {'time': 1704067320.0, 'close': 1.3},
+        ]
+        original = [row.copy() for row in rates]
+
+        shifted = _shift_rate_times(rates, 60)
+
+        self.assertIsInstance(shifted, list)
+        self.assertIsNot(shifted, rates)
+        self.assertEqual(rates, original)
+        self.assertEqual(shifted[0]['time'], 1704067260.0)
+        self.assertEqual(shifted[1]['time'], 'not-a-number')
+        self.assertEqual(shifted[2]['time'], 1704067380.0)
+        self.assertEqual(shifted[0]['close'], rates[0]['close'])
+        self.assertEqual(shifted[1]['close'], rates[1]['close'])
+        self.assertEqual(shifted[2]['close'], rates[2]['close'])
+
+    def test_structured_array_with_non_numeric_time_returns_original_untouched_input(self):
+        rates = np.array(
+            [('1704067200.0', 1.1), ('not-a-number', 1.2)],
+            dtype=[('time', 'U32'), ('close', 'f8')],
+        )
+        original = rates.copy()
+
+        shifted = _shift_rate_times(rates, 60)
+
+        self.assertIs(shifted, rates)
+        np.testing.assert_array_equal(rates, original)
+        np.testing.assert_array_equal(shifted, original)
+
 
 # ============================================================================
 # _fetch_rates_with_warmup

--- a/tests/services/test_data_service_coverage.py
+++ b/tests/services/test_data_service_coverage.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 import sys
 import os
 
+import numpy as np
 # Ensure src is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
@@ -26,6 +27,7 @@ import pandas as pd  # noqa: E402
 from mtdata.services.data_service import (  # noqa: E402
     _fetch_rates_with_warmup,
     _build_rates_df,
+    _shift_rate_times,
     _trim_df_to_target,
     fetch_candles,
     fetch_ticks,
@@ -102,6 +104,43 @@ _ESTIMATE_WARMUP = f'{_DS}._estimate_warmup_bars_util'
 _APPLY_TI = f'{_DS}._apply_ta_indicators_util'
 _SIMPLIFY_EXT = f'{_DS}._simplify_dataframe_rows_ext'
 _MT5_CONFIG = f'{_DS}.mt5_config'
+
+
+# ============================================================================
+# _shift_rate_times
+# ============================================================================
+
+class TestShiftRateTimes(unittest.TestCase):
+    def test_returns_shifted_list_copy_without_mutating_input(self):
+        rates = _make_rates(3)
+        original_times = [float(row['time']) for row in rates]
+
+        shifted = _shift_rate_times(rates, 3600)
+
+        self.assertIsInstance(shifted, list)
+        self.assertIsNot(shifted, rates)
+        self.assertIsNot(shifted[0], rates[0])
+        self.assertEqual([float(row['time']) for row in rates], original_times)
+        self.assertEqual(
+            [float(row['time']) for row in shifted],
+            [ts + 3600.0 for ts in original_times],
+        )
+
+    def test_returns_shifted_structured_array_copy_without_mutating_input(self):
+        rates = np.array(
+            [(1704067200.0, 1.1), (1704067260.0, 1.2)],
+            dtype=[('time', 'f8'), ('close', 'f8')],
+        )
+
+        shifted = _shift_rate_times(rates, 120)
+
+        self.assertIsNot(shifted, rates)
+        np.testing.assert_array_equal(rates['time'], np.array([1704067200.0, 1704067260.0]))
+        np.testing.assert_array_equal(
+            shifted['time'],
+            np.array([1704067320.0, 1704067380.0]),
+        )
+        np.testing.assert_array_equal(shifted['close'], rates['close'])
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- resolve `code-reports/to-do/21-inplace-numpy-mutation-shift-rate-times.md`
- stop `_shift_rate_times()` from mutating caller-owned MT5 rate buffers in place
- add regressions for both list-of-dict and structured-array inputs

## Root cause
`_shift_rate_times()` rewrote the `time` field directly on the object returned by MT5. Because the helper returned the same buffer after shifting, callers that reused the original rates object observed surprising in-place mutation.

## Implemented solution
- copy structured arrays before shifting their `time` field
- build copied dict rows for list-backed rates before applying the shift
- keep the existing best-effort error behavior while ensuring failed shifts return the original untouched input
- add focused coverage proving the helper returns shifted copies without mutating the source data

## Trade-offs / limitations
The helper still treats unsupported input shapes as pass-through and still suppresses per-row conversion failures to preserve the current tolerant behavior. This change only removes the in-place mutation side effect.

## Report
- `code-reports/to-do/21-inplace-numpy-mutation-shift-rate-times.md`
