### PR TITLE
patterns: share status helpers

### DIFF
--- a/src/mtdata/core/patterns.py
+++ b/src/mtdata/core/patterns.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
 import math
 from typing import Any, Callable, Dict, Optional, List, Tuple, Literal
-import importlib
 import copy
 import logging
 import numpy as np
@@ -12,8 +11,9 @@ from .constants import TIMEFRAME_MAP, TIMEFRAME_SECONDS
 from .execution_logging import run_logged_operation
 from .mt5_gateway import get_mt5_gateway, mt5_connection_error
 from .patterns_support import (
-    _STOCK_PATTERN_UTILS_CACHE,
+    _STOCK_PATTERN_UTILS_CACHE,  # noqa: F401
     _build_stock_pattern_frame,
+    _count_patterns_with_status,
     _compact_patterns_payload,
     _elliott_completed_preview,
     _elliott_hidden_completed_note,
@@ -23,20 +23,22 @@ from .patterns_support import (
     _format_pattern_dates,
     _index_pos_for_timestamp,
     _infer_stock_pattern_confidence,
-    _interval_overlap_ratio,
+    _interval_overlap_ratio,  # noqa: F401
     _load_stock_pattern_utils,
     _map_stock_pattern_name,
     _merge_classic_ensemble,
     _normalize_engine_name,
     _parse_engine_list,
     _parse_native_scale_factors,
+    _resolve_elliott_pattern_status,
     _resolve_engine_weights,
     _round_value,
     _summarize_engine_findings,
     _summarize_pattern_bias,
     _timestamp_to_label,
-    _to_float_safe,
+    _to_float_safe,  # noqa: F401
     _to_jsonable,
+    _visible_pattern_rows,
 )
 from ..utils.utils import _parse_bool_like, _UNPARSED_BOOL
 from ..utils.mt5 import _mt5_copy_rates_from
@@ -50,7 +52,7 @@ from .patterns_requests import PatternsDetectRequest
 from .patterns_use_cases import PatternsDetectDeps, run_patterns_detect
 from ..shared.validators import invalid_timeframe_error
 from ..utils.denoise import _apply_denoise as _apply_denoise_util, normalize_denoise_spec as _normalize_denoise_spec
-from ..utils.mt5 import MT5ConnectionError, ensure_mt5_connection_or_raise, mt5
+from ..utils.mt5 import ensure_mt5_connection_or_raise, mt5
 
 logger = logging.getLogger(__name__)
 
@@ -274,12 +276,8 @@ def _build_pattern_response(
 ) -> Dict[str, Any]:
     """Build the response dict for pattern detection results."""
     # Filter patterns based on include_completed
-    filtered = patterns if include_completed else [
-        d for d in patterns if str(d.get('status', '')).lower() == 'forming'
-    ]
-    completed_hidden = 0 if include_completed else int(
-        sum(1 for d in patterns if str(d.get("status", "")).lower() == "completed")
-    )
+    filtered = _visible_pattern_rows(patterns, include_completed=include_completed)
+    completed_hidden = 0 if include_completed else _count_patterns_with_status(patterns, "completed")
     elliott_preview = (
         _elliott_completed_preview(patterns, timeframe=timeframe)
         if str(mode).lower() == "elliott" and completed_hidden > 0
@@ -355,7 +353,11 @@ def _format_elliott_patterns(df: pd.DataFrame, cfg: _ElliottCfg) -> List[Dict[st
                 recent_bars = max(1, int(raw_recent_bars))
             else:
                 recent_bars = 3
-            status = 'forming' if int(p.end_index) >= int(n_bars - recent_bars) else 'completed'
+            status = _resolve_elliott_pattern_status(
+                p.end_index,
+                n_bars=n_bars,
+                recent_bars=recent_bars,
+            )
 
             out_list.append(
                 {

--- a/src/mtdata/core/patterns_support.py
+++ b/src/mtdata/core/patterns_support.py
@@ -49,6 +49,48 @@ def _pattern_label(row: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _pattern_status_value(row: Any) -> str:
+    try:
+        return str(row.get("status", "")).strip().lower()
+    except Exception:
+        return ""
+
+
+def _pattern_has_status(row: Any, status: str) -> bool:
+    return _pattern_status_value(row) == str(status).strip().lower()
+
+
+def _count_patterns_with_status(rows: List[Dict[str, Any]], status: str) -> int:
+    return int(sum(1 for row in rows if _pattern_has_status(row, status)))
+
+
+def _visible_pattern_rows(
+    rows: List[Dict[str, Any]],
+    *,
+    include_completed: bool,
+) -> List[Dict[str, Any]]:
+    if include_completed:
+        return rows
+    return [row for row in rows if _pattern_has_status(row, "forming")]
+
+
+def _resolve_elliott_pattern_status(
+    end_index: Any,
+    *,
+    n_bars: int,
+    recent_bars: int,
+) -> str:
+    try:
+        recent = max(1, int(recent_bars))
+    except Exception:
+        recent = 1
+    try:
+        end_idx = int(end_index)
+    except Exception:
+        end_idx = -1
+    return "forming" if end_idx >= int(max(0, n_bars - recent)) else "completed"
+
+
 def _elliott_preview_sort_key(row: Dict[str, Any]) -> Tuple[float, float, str]:
     conf = _safe_float(row.get("confidence")) or 0.0
     end_idx = _safe_float(row.get("end_index"))
@@ -67,7 +109,7 @@ def _elliott_completed_preview(
     completed_rows = [
         row
         for row in patterns
-        if isinstance(row, dict) and str(row.get("status", "")).strip().lower() == "completed"
+        if isinstance(row, dict) and _pattern_has_status(row, "completed")
     ]
     preview: List[Dict[str, Any]] = []
     for row in sorted(completed_rows, key=_elliott_preview_sort_key, reverse=True)[: int(limit)]:
@@ -1143,8 +1185,8 @@ def _summarize_engine_findings(
     for engine in engines:
         rows = [row for row in per_engine.get(engine, []) if isinstance(row, dict)]
         n_total = int(len(rows))
-        n_forming = int(sum(1 for row in rows if str(row.get("status", "")).lower() == "forming"))
-        n_completed = int(sum(1 for row in rows if str(row.get("status", "")).lower() == "completed"))
+        n_forming = _count_patterns_with_status(rows, "forming")
+        n_completed = _count_patterns_with_status(rows, "completed")
         n_shown = n_total if include_completed else n_forming
         item: Dict[str, Any] = {
             "engine": engine,

--- a/tests/patterns/test_patterns_core_coverage.py
+++ b/tests/patterns/test_patterns_core_coverage.py
@@ -1,10 +1,9 @@
 """Tests for mtdata.core.patterns — pattern detection helpers and tool wrappers."""
 
-import copy
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
-from unittest.mock import MagicMock, patch, PropertyMock
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -140,6 +139,32 @@ class TestParseEngineList:
 
     def test_scalar_fallback(self):
         assert self._call(42) == ["42"]
+
+
+# ── pattern status helpers ─────────────────────────────────────────────────
+
+class TestPatternStatusHelpers:
+
+    def test_visible_pattern_rows_and_counts_share_status_normalization(self):
+        from mtdata.core.patterns_support import _count_patterns_with_status, _visible_pattern_rows
+
+        rows = [
+            {"status": " forming "},
+            {"status": "COMPLETED"},
+            {"status": "other"},
+        ]
+
+        visible = _visible_pattern_rows(rows, include_completed=False)
+
+        assert visible == [rows[0]]
+        assert _count_patterns_with_status(rows, "forming") == 1
+        assert _count_patterns_with_status(rows, "completed") == 1
+
+    def test_resolve_elliott_pattern_status_uses_recent_window(self):
+        from mtdata.core.patterns_support import _resolve_elliott_pattern_status
+
+        assert _resolve_elliott_pattern_status(8, n_bars=10, recent_bars=3) == "forming"
+        assert _resolve_elliott_pattern_status(6, n_bars=10, recent_bars=3) == "completed"
 
 
 # ── _select_classic_engines ───────────────────────────────────────────────
@@ -629,7 +654,6 @@ class TestEnrichClassicPatterns:
 
     def test_forming_patterns_project_line_levels_to_current_bar(self):
         from mtdata.core.patterns_support import _enrich_classic_patterns
-        from mtdata.patterns.classic import ClassicDetectorConfig
 
         df = _make_ohlcv_df(6)
         rows = [
@@ -1261,7 +1285,7 @@ class TestPatternsDetect:
     @patch("mtdata.core.patterns._detect_candlestick_patterns")
     def test_candlestick_mode(self, mock_detect):
         mock_detect.return_value = {"success": True, "patterns": []}
-        result = _call_patterns_detect(symbol="EURUSD", mode="candlestick")
+        _call_patterns_detect(symbol="EURUSD", mode="candlestick")
         mock_detect.assert_called_once()
 
     def test_unknown_mode(self):


### PR DESCRIPTION
## Summary
- consolidate forming/completed status handling for pattern responses and Elliott previews
- keep `mtdata.core.patterns` helper re-exports intact while moving the shared logic into `patterns_support`
- add focused helper coverage for status normalization and Elliott completion classification

## Root cause
Pattern status derivation and selection lived in multiple places: `_format_elliott_patterns()` classified Elliott rows inline, `_build_pattern_response()` separately filtered forming rows, and `_elliott_completed_preview()` counted completed rows independently. That duplication made it easy for response filtering, previews, and per-engine summaries to drift out of sync.

## Implemented solution
- added shared status helpers in `src/mtdata/core/patterns_support.py` for status normalization, forming/completed counting, visible-row filtering, and Elliott completion classification
- updated `src/mtdata/core/patterns.py` to reuse those helpers from `_build_pattern_response()` and `_format_elliott_patterns()`
- updated `_summarize_engine_findings()` and `_elliott_completed_preview()` to use the same shared status logic
- added regression coverage in `tests/patterns/test_patterns_core_coverage.py`

## Trade-offs / limitations
This is a refactor for consistency rather than a behavior change. `mtdata.core.patterns` still re-exports a few helper symbols for compatibility with existing callers and tests.

## Report reference
- `code-reports/to-do/issue-13-pattern-status-consolidation.md`
