### PR TITLE
forecast: mark gluonts methods unsupported on 3.14

### DIFF
--- a/src/mtdata/forecast/forecast_registry.py
+++ b/src/mtdata/forecast/forecast_registry.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Tuple
 from functools import lru_cache
 import importlib as _importlib
 import importlib.util as _importlib_util
+import sys
 
 from .registry import ForecastRegistry
 
@@ -17,6 +18,32 @@ DEFAULT_METHOD_SUPPORTS: Dict[str, bool] = {
     "volatility": False,
     "ci": False,
 }
+
+_FORECAST_METHOD_MODULES = (
+    "classical",
+    "ets_arima",
+    "statsforecast",
+    "mlforecast",
+    "pretrained",
+    "neural",
+    "sktime",
+    "gluonts_extra",
+    "analog",
+    "ensemble",
+    "monte_carlo",
+)
+_PYTHON_314_PLUS = sys.version_info >= (3, 14)
+_GLUONTS_EXTRA_METHODS = {
+    "gt_deepar",
+    "gt_sfeedforward",
+    "gt_prophet",
+    "gt_tft",
+    "gt_wavenet",
+    "gt_deepnpts",
+    "gt_mqf2",
+    "gt_npts",
+}
+_GLUONTS_PYTHON_RUNTIME_REQUIREMENT = "Python < 3.14 (GluonTS methods are unsupported in this project)"
 
 # Import availability checkers
 try:
@@ -177,6 +204,9 @@ def _check_requirements(method: str, requires: List[str]) -> Tuple[bool, List[st
         available = False; reqs.append("lag-llama, gluonts, torch")
     if method == "sktime" and not _SKTIME_AVAILABLE:
         available = False; reqs.append("sktime")
+    if method in _GLUONTS_EXTRA_METHODS and _PYTHON_314_PLUS:
+        available = False
+        reqs.append(_GLUONTS_PYTHON_RUNTIME_REQUIREMENT)
 
     module_name_overrides = {
         "scikit-learn": "sklearn",
@@ -188,6 +218,8 @@ def _check_requirements(method: str, requires: List[str]) -> Tuple[bool, List[st
     for req in list(reqs):
         name = str(req).strip()
         if not name:
+            continue
+        if name.lower().startswith("python "):
             continue
         for sep in (">=", "==", "<=", "~=", ">", "<"):
             if sep in name:
@@ -205,20 +237,12 @@ def _check_requirements(method: str, requires: List[str]) -> Tuple[bool, List[st
 
 def _ensure_registry_loaded() -> None:
     """Ensure ForecastRegistry is populated by importing method modules."""
-    try:
-        from .methods import classical  # noqa: F401
-        from .methods import ets_arima  # noqa: F401
-        from .methods import statsforecast  # noqa: F401
-        from .methods import mlforecast  # noqa: F401
-        from .methods import pretrained  # noqa: F401
-        from .methods import neural  # noqa: F401
-        from .methods import sktime  # noqa: F401
-        from .methods import gluonts_extra  # noqa: F401
-        from .methods import analog  # noqa: F401
-        from .methods import ensemble  # noqa: F401
-        from .methods import monte_carlo  # noqa: F401
-    except Exception:
-        pass
+    base_package = f"{__package__}.methods"
+    for module_name in _FORECAST_METHOD_MODULES:
+        try:
+            _importlib.import_module(f"{base_package}.{module_name}")
+        except Exception:
+            continue
 
 
 def _ensemble_metadata() -> Dict[str, Any]:

--- a/src/mtdata/forecast/forecast_registry.py
+++ b/src/mtdata/forecast/forecast_registry.py
@@ -44,6 +44,18 @@ _GLUONTS_EXTRA_METHODS = {
     "gt_npts",
 }
 _GLUONTS_PYTHON_RUNTIME_REQUIREMENT = "Python < 3.14 (GluonTS methods are unsupported in this project)"
+_OPTIONAL_FORECAST_METHOD_MODULES = frozenset(
+    {
+        "statsforecast",
+        "mlforecast",
+        "pretrained",
+        "neural",
+        "sktime",
+        "gluonts_extra",
+    }
+)
+_LOADED_FORECAST_METHOD_MODULES: set[str] = set()
+_FAILED_OPTIONAL_FORECAST_MODULES: Dict[str, str] = {}
 
 # Import availability checkers
 try:
@@ -239,10 +251,23 @@ def _ensure_registry_loaded() -> None:
     """Ensure ForecastRegistry is populated by importing method modules."""
     base_package = f"{__package__}.methods"
     for module_name in _FORECAST_METHOD_MODULES:
+        if module_name in _LOADED_FORECAST_METHOD_MODULES:
+            continue
+        if module_name in _FAILED_OPTIONAL_FORECAST_MODULES:
+            continue
         try:
             _importlib.import_module(f"{base_package}.{module_name}")
-        except Exception:
+        except ModuleNotFoundError as exc:
+            if module_name not in _OPTIONAL_FORECAST_METHOD_MODULES:
+                raise
+            _FAILED_OPTIONAL_FORECAST_MODULES[module_name] = str(exc)
             continue
+        except ImportError as exc:
+            if module_name not in _OPTIONAL_FORECAST_METHOD_MODULES:
+                raise
+            _FAILED_OPTIONAL_FORECAST_MODULES[module_name] = str(exc)
+            continue
+        _LOADED_FORECAST_METHOD_MODULES.add(module_name)
 
 
 def _ensemble_metadata() -> Dict[str, Any]:

--- a/tests/forecast/test_forecast_registry_business_logic.py
+++ b/tests/forecast/test_forecast_registry_business_logic.py
@@ -53,6 +53,37 @@ def test_check_requirements_marks_chronos_unavailable_on_runtime_mismatch(monkey
     assert "chronos-forecasting>=2.0.0" in reqs
 
 
+def test_check_requirements_marks_gluonts_extra_methods_unsupported_on_python_314(monkeypatch):
+    monkeypatch.setattr(fr, "_PYTHON_314_PLUS", True)
+    monkeypatch.setattr(fr._importlib_util, "find_spec", lambda _name: object())
+
+    available, reqs = fr._check_requirements("gt_deepar", ["gluonts", "torch"])
+
+    assert available is False
+    assert fr._GLUONTS_PYTHON_RUNTIME_REQUIREMENT in reqs
+
+
+def test_ensure_registry_loaded_continues_after_one_module_import_failure(monkeypatch):
+    imported = []
+
+    def fake_import(name):
+        imported.append(name)
+        if name.endswith(".gluonts_extra"):
+            raise ImportError("unsupported runtime")
+        return object()
+
+    monkeypatch.setattr(fr, "_FORECAST_METHOD_MODULES", ("classical", "gluonts_extra", "analog"))
+    monkeypatch.setattr(fr._importlib, "import_module", fake_import)
+
+    fr._ensure_registry_loaded()
+
+    assert imported == [
+        "mtdata.forecast.methods.classical",
+        "mtdata.forecast.methods.gluonts_extra",
+        "mtdata.forecast.methods.analog",
+    ]
+
+
 def test_get_forecast_methods_data_assembles_categories_and_skips_broken(monkeypatch):
     class GoodMethod:
         """Good method summary."""

--- a/tests/forecast/test_forecast_registry_business_logic.py
+++ b/tests/forecast/test_forecast_registry_business_logic.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mtdata.forecast import forecast_registry as fr
 
 
@@ -73,6 +75,9 @@ def test_ensure_registry_loaded_continues_after_one_module_import_failure(monkey
         return object()
 
     monkeypatch.setattr(fr, "_FORECAST_METHOD_MODULES", ("classical", "gluonts_extra", "analog"))
+    monkeypatch.setattr(fr, "_OPTIONAL_FORECAST_METHOD_MODULES", frozenset({"gluonts_extra"}))
+    monkeypatch.setattr(fr, "_LOADED_FORECAST_METHOD_MODULES", set())
+    monkeypatch.setattr(fr, "_FAILED_OPTIONAL_FORECAST_MODULES", {})
     monkeypatch.setattr(fr._importlib, "import_module", fake_import)
 
     fr._ensure_registry_loaded()
@@ -82,6 +87,49 @@ def test_ensure_registry_loaded_continues_after_one_module_import_failure(monkey
         "mtdata.forecast.methods.gluonts_extra",
         "mtdata.forecast.methods.analog",
     ]
+    assert fr._LOADED_FORECAST_METHOD_MODULES == {"classical", "analog"}
+    assert fr._FAILED_OPTIONAL_FORECAST_MODULES == {"gluonts_extra": "unsupported runtime"}
+
+
+def test_ensure_registry_loaded_memoizes_optional_import_failures(monkeypatch):
+    imported = []
+
+    def fake_import(name):
+        imported.append(name)
+        if name.endswith(".gluonts_extra"):
+            raise ImportError("unsupported runtime")
+        return object()
+
+    monkeypatch.setattr(fr, "_FORECAST_METHOD_MODULES", ("classical", "gluonts_extra", "analog"))
+    monkeypatch.setattr(fr, "_OPTIONAL_FORECAST_METHOD_MODULES", frozenset({"gluonts_extra"}))
+    monkeypatch.setattr(fr, "_LOADED_FORECAST_METHOD_MODULES", set())
+    monkeypatch.setattr(fr, "_FAILED_OPTIONAL_FORECAST_MODULES", {})
+    monkeypatch.setattr(fr._importlib, "import_module", fake_import)
+
+    fr._ensure_registry_loaded()
+    fr._ensure_registry_loaded()
+
+    assert imported == [
+        "mtdata.forecast.methods.classical",
+        "mtdata.forecast.methods.gluonts_extra",
+        "mtdata.forecast.methods.analog",
+    ]
+
+
+def test_ensure_registry_loaded_reraises_non_optional_import_errors(monkeypatch):
+    def fake_import(name):
+        if name.endswith(".classical"):
+            raise ImportError("core import broke")
+        return object()
+
+    monkeypatch.setattr(fr, "_FORECAST_METHOD_MODULES", ("classical",))
+    monkeypatch.setattr(fr, "_OPTIONAL_FORECAST_METHOD_MODULES", frozenset({"gluonts_extra"}))
+    monkeypatch.setattr(fr, "_LOADED_FORECAST_METHOD_MODULES", set())
+    monkeypatch.setattr(fr, "_FAILED_OPTIONAL_FORECAST_MODULES", {})
+    monkeypatch.setattr(fr._importlib, "import_module", fake_import)
+
+    with pytest.raises(ImportError, match="core import broke"):
+        fr._ensure_registry_loaded()
 
 
 def test_get_forecast_methods_data_assembles_categories_and_skips_broken(monkeypatch):


### PR DESCRIPTION
## Summary
- mark the dormant `gt_*` GluonTS methods as explicitly unsupported on Python 3.14 in forecast method metadata
- stop one forecast-method module import failure from short-circuiting the rest of registry loading
- add focused registry tests for both behaviors

## Root cause
The forecast registry still imported and registered the GluonTS extra methods even though this project targets Python 3.14 and does not package the GluonTS dependency stack for that runtime. At the same time, `_ensure_registry_loaded()` wrapped the whole module-import sequence in one broad `try/except`, so a single import failure could silently stop later forecast modules from loading.

## Implemented solution
- added an explicit Python runtime requirement marker for `gt_*` methods in `src/mtdata/forecast/forecast_registry.py`, so they report as unavailable on Python 3.14 with a clear diagnostic
- changed `_ensure_registry_loaded()` to import forecast method modules one-by-one so later modules still load if one optional module fails
- added focused tests in `tests/forecast/test_forecast_registry_business_logic.py`

## Trade-offs / limitations
This keeps the existing GluonTS method module importable for tests and stubs; it does not try to make GluonTS installable on Python 3.14. The packaging-side work remains isolated to PR #35.

## Report reference
- `code-reports/to-do/issue-10-orphaned-gluonts-code.md`
