### PR TITLE
core: dedupe candle-close wait boundaries

### DIFF
--- a/src/mtdata/core/data_requests.py
+++ b/src/mtdata/core/data_requests.py
@@ -506,6 +506,10 @@ def _normalize_wait_event_spec_item(value: Any) -> Any:
     return normalized
 
 
+def _is_candle_close_wait_event(value: Any) -> bool:
+    return isinstance(value, dict) and str(value.get("type") or "").strip() == "candle_close"
+
+
 def _normalize_wait_event_request_payload(value: Any) -> Any:
     if not isinstance(value, dict):
         return value
@@ -520,19 +524,23 @@ def _normalize_wait_event_request_payload(value: Any) -> Any:
     watch_for_out: List[Any] = []
     end_on_out: List[Any] = []
 
+    def append_unique_boundary_event(item: Any) -> None:
+        if item not in end_on_out:
+            end_on_out.append(item)
+
     if isinstance(watch_for_input, list):
         for item in watch_for_input:
             normalized = _normalize_wait_event_spec_item(item)
-            if isinstance(normalized, dict) and str(normalized.get("type") or "").strip() == "candle_close":
-                end_on_out.append(normalized)
+            if _is_candle_close_wait_event(normalized):
+                append_unique_boundary_event(normalized)
             else:
                 watch_for_out.append(normalized)
 
     if isinstance(end_on_input, list):
         for item in end_on_input:
             normalized = _normalize_wait_event_spec_item(item)
-            if isinstance(normalized, dict) and str(normalized.get("type") or "").strip() == "candle_close":
-                end_on_out.append(normalized)
+            if _is_candle_close_wait_event(normalized):
+                append_unique_boundary_event(normalized)
             else:
                 watch_for_out.append(normalized)
 

--- a/src/mtdata/core/data_requests.py
+++ b/src/mtdata/core/data_requests.py
@@ -510,6 +510,12 @@ def _is_candle_close_wait_event(value: Any) -> bool:
     return isinstance(value, dict) and str(value.get("type") or "").strip() == "candle_close"
 
 
+def _canonicalize_candle_close_wait_event(value: Any) -> Any:
+    if not _is_candle_close_wait_event(value):
+        return value
+    return CandleCloseEventSpec.model_validate(value).model_dump(exclude_none=True)
+
+
 def _normalize_wait_event_request_payload(value: Any) -> Any:
     if not isinstance(value, dict):
         return value
@@ -525,8 +531,9 @@ def _normalize_wait_event_request_payload(value: Any) -> Any:
     end_on_out: List[Any] = []
 
     def append_unique_boundary_event(item: Any) -> None:
-        if item not in end_on_out:
-            end_on_out.append(item)
+        canonical_item = _canonicalize_candle_close_wait_event(item)
+        if canonical_item not in end_on_out:
+            end_on_out.append(canonical_item)
 
     if isinstance(watch_for_input, list):
         for item in watch_for_input:

--- a/tests/core/test_wait_event.py
+++ b/tests/core/test_wait_event.py
@@ -149,6 +149,21 @@ def test_wait_event_request_deduplicates_identical_candle_close_events() -> None
     assert [(item.type, item.timeframe) for item in request.end_on] == [("candle_close", "M15")]
 
 
+def test_wait_event_request_deduplicates_candle_close_events_with_null_optionals() -> None:
+    request = WaitEventRequest.model_validate(
+        {
+            "symbol": "EURUSD",
+            "watch_for": [{"type": "candle_close", "timeframe": "M15", "buffer_seconds": None}],
+            "end_on": [{"type": "candle_close", "timeframe": "M15"}],
+        }
+    )
+
+    assert request.watch_for == []
+    assert [(item.type, item.timeframe, item.buffer_seconds) for item in request.end_on] == [
+        ("candle_close", "M15", None),
+    ]
+
+
 def test_wait_event_request_preserves_distinct_candle_close_boundaries() -> None:
     request = WaitEventRequest.model_validate(
         {

--- a/tests/core/test_wait_event.py
+++ b/tests/core/test_wait_event.py
@@ -131,3 +131,35 @@ def test_wait_event_request_normalizes_legacy_event_names() -> None:
     assert [item.type for item in request.watch_for] == ["price_touch_level"]
     assert [item.type for item in request.end_on] == ["candle_close"]
     assert request.end_on[0].timeframe == "M15"
+
+
+def test_wait_event_request_deduplicates_identical_candle_close_events() -> None:
+    request = WaitEventRequest.model_validate(
+        {
+            "symbol": "EURUSD",
+            "watch_for": [
+                {"type": "candle_close", "timeframe": "M15"},
+                {"type": "price_level_touch", "level": 1.1454, "tolerance": 0.0002},
+            ],
+            "end_on": [{"type": "candle_close", "timeframe": "M15"}],
+        }
+    )
+
+    assert [item.type for item in request.watch_for] == ["price_touch_level"]
+    assert [(item.type, item.timeframe) for item in request.end_on] == [("candle_close", "M15")]
+
+
+def test_wait_event_request_preserves_distinct_candle_close_boundaries() -> None:
+    request = WaitEventRequest.model_validate(
+        {
+            "symbol": "EURUSD",
+            "watch_for": [{"type": "candle_close", "timeframe": "M15"}],
+            "end_on": [{"type": "candle_close", "timeframe": "M5"}],
+        }
+    )
+
+    assert request.watch_for == []
+    assert [(item.type, item.timeframe) for item in request.end_on] == [
+        ("candle_close", "M15"),
+        ("candle_close", "M5"),
+    ]


### PR DESCRIPTION
## Summary
- dedupe identical `candle_close` boundary events while normalizing `WaitEventRequest` payloads
- keep distinct boundary events intact when `watch_for` and `end_on` specify different candle-close criteria
- add regression coverage for duplicate and distinct boundary inputs

## Root cause
`_normalize_wait_event_request_payload()` routed `candle_close` items from both `watch_for` and `end_on` into the same `end_on_out` list, but it appended every normalized boundary item blindly. When the same `candle_close` spec appeared in both inputs, the validator produced duplicate boundary events.

## Implemented solution
- add a small helper to recognize `candle_close` boundary specs
- append boundary events through a unique-append path so identical normalized entries are only kept once
- add request-model tests covering duplicate and distinct candle-close combinations

## Trade-offs / limitations
- identical `candle_close` boundary specs are now collapsed to a single entry during normalization; distinct boundaries are still preserved in input order
- the change is intentionally scoped to payload normalization and does not alter downstream wait execution logic

## Report
- Resolves `code-reports/to-do/HIGH-wait-event-type-alias-flaw.md`