### PR TITLE
utils: fix MACD warmup estimate

### DIFF
--- a/src/mtdata/utils/indicators.py
+++ b/src/mtdata/utils/indicators.py
@@ -406,10 +406,11 @@ def _estimate_warmup_bars(ti_spec: Optional[str]) -> int:
         elif lname == "macd":
             fast = kwargs.get("fast", args[0] if len(args) > 0 else 12)
             slow = kwargs.get("slow", args[1] if len(args) > 1 else 26)
+            signal = kwargs.get("signal", args[2] if len(args) > 2 else 9)
             try:
-                warm = int(max(int(fast), int(slow)))
+                warm = max(int(fast), int(slow)) + int(signal)
             except Exception:
-                warm = 26
+                warm = 35
         elif lname == "stoch":
             k = kwargs.get("k", args[0] if len(args) > 0 else 14)
             d = kwargs.get("d", args[1] if len(args) > 1 else 3)

--- a/tests/utils/test_indicators_pure.py
+++ b/tests/utils/test_indicators_pure.py
@@ -257,7 +257,11 @@ class TestEstimateWarmupBars:
 
     def test_macd(self):
         result = _estimate_warmup_bars("macd(12,26,9)")
-        assert result >= 50
+        assert result == 105
+
+    def test_macd_uses_default_signal_when_missing(self):
+        result = _estimate_warmup_bars("macd(fast=12,slow=26)")
+        assert result == 105
 
     def test_bbands(self):
         result = _estimate_warmup_bars("bbands(20)")


### PR DESCRIPTION
## Summary
- include the MACD signal period in warmup estimation
- use a conservative `max(fast, slow) + signal` warmup calculation so unusual parameter order still gets enough history
- tighten the regression tests to assert the exact warmup returned for standard and default-signal MACD specs

## Root cause
`_estimate_warmup_bars()` handled MACD warmup as `max(fast, slow)` and ignored the signal period entirely. For standard `macd(12,26,9)`, that returned 26 before scaling instead of 35, so the fetch layer could request too little history for MACD output.

## Implemented solution
- parse the MACD signal parameter alongside fast and slow
- compute MACD warmup as `max(fast, slow) + signal`
- fall back to the standard 35-bar MACD warmup when parsing fails
- update pure indicator tests to assert the exact 105-bar scaled warmup for standard and default-signal MACD specs

## Trade-offs / limitations
- this change only affects warmup estimation, not MACD calculation itself
- the estimate remains conservative because the fetch layer still multiplies warmup by the existing scaling factor

## Report
- Resolves `code-reports/to-do/HIGH-macd-warmup-bar-estimation.md`