### PR TITLE
core: lock stock pattern cache init

### DIFF
--- a/src/mtdata/core/patterns_support.py
+++ b/src/mtdata/core/patterns_support.py
@@ -1,4 +1,5 @@
 import importlib
+import threading
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -31,6 +32,7 @@ _STOCK_PATTERN_CODE_TO_NAME = {
     "BFLYD": "Bear Butterfly",
 }
 _STOCK_PATTERN_UTILS_CACHE: Dict[str, Any] = {}
+_STOCK_PATTERN_UTILS_CACHE_LOCK = threading.Lock()
 
 
 def _round_value(x: Any) -> Any:
@@ -1270,18 +1272,19 @@ def _load_stock_pattern_utils(config: Optional[Dict[str, Any]]) -> Tuple[Optiona
     required = ("get_max_min", "find_double_top", "find_double_bottom")
     last_err: Optional[str] = None
     for module_name in candidate_modules:
-        if module_name in _STOCK_PATTERN_UTILS_CACHE:
-            return _STOCK_PATTERN_UTILS_CACHE[module_name], None
-        try:
-            module = importlib.import_module(module_name)
-        except Exception as ex:
-            last_err = str(ex)
-            continue
-        if not all(callable(getattr(module, fn, None)) for fn in required):
-            last_err = f"module '{module_name}' missing required stock-pattern functions"
-            continue
-        _STOCK_PATTERN_UTILS_CACHE[module_name] = module
-        return module, None
+        with _STOCK_PATTERN_UTILS_CACHE_LOCK:
+            if module_name in _STOCK_PATTERN_UTILS_CACHE:
+                return _STOCK_PATTERN_UTILS_CACHE[module_name], None
+            try:
+                module = importlib.import_module(module_name)
+            except Exception as ex:
+                last_err = str(ex)
+                continue
+            if not all(callable(getattr(module, fn, None)) for fn in required):
+                last_err = f"module '{module_name}' missing required stock-pattern functions"
+                continue
+            _STOCK_PATTERN_UTILS_CACHE[module_name] = module
+            return module, None
 
     tail = f" Last import error: {last_err}" if last_err else ""
     return None, (

--- a/src/mtdata/core/patterns_support.py
+++ b/src/mtdata/core/patterns_support.py
@@ -1272,9 +1272,14 @@ def _load_stock_pattern_utils(config: Optional[Dict[str, Any]]) -> Tuple[Optiona
     required = ("get_max_min", "find_double_top", "find_double_bottom")
     last_err: Optional[str] = None
     for module_name in candidate_modules:
+        module = _STOCK_PATTERN_UTILS_CACHE.get(module_name)
+        if module is not None:
+            return module, None
+
         with _STOCK_PATTERN_UTILS_CACHE_LOCK:
-            if module_name in _STOCK_PATTERN_UTILS_CACHE:
-                return _STOCK_PATTERN_UTILS_CACHE[module_name], None
+            module = _STOCK_PATTERN_UTILS_CACHE.get(module_name)
+            if module is not None:
+                return module, None
             try:
                 module = importlib.import_module(module_name)
             except Exception as ex:

--- a/tests/patterns/test_patterns_core_coverage.py
+++ b/tests/patterns/test_patterns_core_coverage.py
@@ -1006,33 +1006,36 @@ class TestLoadStockPatternUtils:
         from mtdata.core.patterns import _load_stock_pattern_utils, _STOCK_PATTERN_UTILS_CACHE
 
         _STOCK_PATTERN_UTILS_CACHE.clear()
-        mock_mod = MagicMock()
-        mock_mod.get_max_min = MagicMock()
-        mock_mod.find_double_top = MagicMock()
-        mock_mod.find_double_bottom = MagicMock()
+        try:
+            mock_mod = MagicMock()
+            mock_mod.get_max_min = MagicMock()
+            mock_mod.find_double_top = MagicMock()
+            mock_mod.find_double_bottom = MagicMock()
 
-        call_count = 0
-        call_count_lock = threading.Lock()
-        start_barrier = threading.Barrier(2)
+            call_count = 0
+            call_count_lock = threading.Lock()
+            start_barrier = threading.Barrier(2)
 
-        def slow_import(name):
-            nonlocal call_count
-            with call_count_lock:
-                call_count += 1
-            time.sleep(0.05)
-            return mock_mod
+            def slow_import(name):
+                nonlocal call_count
+                with call_count_lock:
+                    call_count += 1
+                time.sleep(0.05)
+                return mock_mod
 
-        mock_import.side_effect = slow_import
+            mock_import.side_effect = slow_import
 
-        def worker():
-            start_barrier.wait()
-            return _load_stock_pattern_utils(None)
+            def worker():
+                start_barrier.wait()
+                return _load_stock_pattern_utils(None)
 
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            results = list(executor.map(lambda _: worker(), range(2)))
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(lambda _: worker(), range(2)))
 
-        assert call_count == 1
-        assert results == [(mock_mod, None), (mock_mod, None)]
+            assert call_count == 1
+            assert results == [(mock_mod, None), (mock_mod, None)]
+        finally:
+            _STOCK_PATTERN_UTILS_CACHE.clear()
 
 
 # ── _fetch_pattern_data ──────────────────────────────────────────────────

--- a/tests/patterns/test_patterns_core_coverage.py
+++ b/tests/patterns/test_patterns_core_coverage.py
@@ -1,5 +1,8 @@
 """Tests for mtdata.core.patterns — pattern detection helpers and tool wrappers."""
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Dict
@@ -997,6 +1000,39 @@ class TestLoadStockPatternUtils:
         mod, err = self._call()
         assert mod is not None
         assert err is None
+
+    @patch("importlib.import_module")
+    def test_concurrent_calls_import_once(self, mock_import):
+        from mtdata.core.patterns import _load_stock_pattern_utils, _STOCK_PATTERN_UTILS_CACHE
+
+        _STOCK_PATTERN_UTILS_CACHE.clear()
+        mock_mod = MagicMock()
+        mock_mod.get_max_min = MagicMock()
+        mock_mod.find_double_top = MagicMock()
+        mock_mod.find_double_bottom = MagicMock()
+
+        call_count = 0
+        call_count_lock = threading.Lock()
+        start_barrier = threading.Barrier(2)
+
+        def slow_import(name):
+            nonlocal call_count
+            with call_count_lock:
+                call_count += 1
+            time.sleep(0.05)
+            return mock_mod
+
+        mock_import.side_effect = slow_import
+
+        def worker():
+            start_barrier.wait()
+            return _load_stock_pattern_utils(None)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _: worker(), range(2)))
+
+        assert call_count == 1
+        assert results == [(mock_mod, None), (mock_mod, None)]
 
 
 # ── _fetch_pattern_data ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- protect stock-pattern utility cache initialization with a module-level lock
- keep the first successful module import cached while preventing duplicate concurrent initialization
- add a concurrent regression test that forces a slow import and asserts only one import occurs

## Root cause
`_load_stock_pattern_utils()` read and wrote `_STOCK_PATTERN_UTILS_CACHE` without synchronization. Under concurrent requests, multiple threads could observe an empty cache, race into `import_module()`, and attempt to initialize the same cache entry at once.

## Implemented solution
- add a dedicated lock for stock-pattern utility cache initialization
- guard the cache hit check, import, validation, and cache write inside the lock so only one thread initializes a module at a time
- add a thread-based regression test that starts two workers together and confirms only one import call happens

## Trade-offs / limitations
- first-time stock-pattern module import is now serialized across threads, which is acceptable because it happens only on cache miss
- this PR intentionally leaves cache eviction behavior unchanged; it only addresses concurrent initialization

## Report
- Resolves `code-reports/to-do/HIGH-race-condition-stock-pattern-cache.md`