### PR TITLE
forecast: clarify stacking weights metadata

### DIFF
--- a/src/mtdata/forecast/methods/ensemble.py
+++ b/src/mtdata/forecast/methods/ensemble.py
@@ -394,6 +394,7 @@ class EnsembleMethod(ForecastMethod):
         rmse = None
         ensemble_intercept = 0.0
         coeffs = None
+        stacking_weight_semantics = None
         cv_rows = 0
         if mode in ('bma', 'stacking'):
             prepare_kwargs: Dict[str, Any] = {}
@@ -494,7 +495,13 @@ class EnsembleMethod(ForecastMethod):
             combined = np.full_like(component_forecasts[0], ensemble_intercept, dtype=float)
             for weight, forecast in zip(coeffs, component_forecasts):
                 combined = combined + float(weight) * forecast
-            weights_vec = coeffs
+            coeff_total = float(np.sum(coeffs))
+            if np.isfinite(coeff_total) and coeff_total > 0:
+                weights_vec = coeffs / coeff_total
+                stacking_weight_semantics = 'normalized_coefficients'
+            else:
+                weights_vec = coeffs
+                stacking_weight_semantics = 'raw_coefficients'
 
         ensemble_meta.update({
             'mode_used': effective_mode,
@@ -507,6 +514,8 @@ class EnsembleMethod(ForecastMethod):
             ensemble_meta['cv_rmse'] = [float(value) for value in rmse.tolist()]
         if effective_mode == 'stacking':
             ensemble_meta['intercept'] = float(ensemble_intercept)
+            ensemble_meta['coefficients'] = [float(value) for value in coeffs.tolist()]
+            ensemble_meta['weight_semantics'] = stacking_weight_semantics
         if cv_failures:
             ensemble_meta['cv_failures'] = cv_failures
         if component_failures:

--- a/tests/forecast/test_ensemble_method_business_logic.py
+++ b/tests/forecast/test_ensemble_method_business_logic.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
+from unittest.mock import patch
 
 from mtdata.forecast.interface import ForecastCallContext
 from mtdata.forecast import forecast_engine as fe
@@ -69,6 +71,40 @@ def test_ensemble_reports_component_failures():
     assert np.allclose(out.forecast, [5.0, 6.0])
     assert out.metadata["component_failures"][0]["method"] == "bad"
     assert out.metadata["component_failures"][0]["error"] == "boom"
+
+
+def test_ensemble_stacking_reports_normalized_weights_and_raw_coefficients():
+    series = pd.Series(np.linspace(1.0, 20.0, 20))
+    method = em.EnsembleMethod()
+
+    def dispatch(method_name, series_in, horizon, seasonality, params):
+        if method_name == "naive":
+            return np.array([10.0, 20.0], dtype=float)
+        return np.array([1.0, 2.0], dtype=float)
+
+    def prepare_cv(*args, **kwargs):
+        return np.ones((3, 2), dtype=float), np.ones(3, dtype=float)
+
+    with patch.object(
+        em.np.linalg,
+        "lstsq",
+        return_value=(np.array([0.5, 2.0, 1.0], dtype=float), np.array([]), 2, np.array([])),
+    ):
+        out = method.forecast(
+            series,
+            horizon=2,
+            seasonality=1,
+            params={"methods": ["naive", "theta"], "mode": "stacking"},
+            ensemble_dispatch_method=dispatch,
+            prepare_ensemble_cv=prepare_cv,
+            get_available_methods=lambda: ("naive", "theta"),
+        )
+
+    assert np.allclose(out.forecast, [21.5, 42.5])
+    assert out.metadata["weights"] == pytest.approx([2.0 / 3.0, 1.0 / 3.0])
+    assert out.metadata["coefficients"] == [2.0, 1.0]
+    assert out.metadata["weight_semantics"] == "normalized_coefficients"
+    assert out.metadata["intercept"] == 0.5
 
 
 def test_ensemble_reports_component_failures_from_dispatch_exceptions():

--- a/tests/forecast/test_ensemble_method_business_logic.py
+++ b/tests/forecast/test_ensemble_method_business_logic.py
@@ -107,6 +107,40 @@ def test_ensemble_stacking_reports_normalized_weights_and_raw_coefficients():
     assert out.metadata["intercept"] == 0.5
 
 
+def test_ensemble_stacking_falls_back_to_raw_coefficients_for_non_positive_sum():
+    series = pd.Series(np.linspace(1.0, 20.0, 20))
+    method = em.EnsembleMethod()
+
+    def dispatch(method_name, series_in, horizon, seasonality, params):
+        if method_name == "naive":
+            return np.array([10.0, 20.0], dtype=float)
+        return np.array([1.0, 2.0], dtype=float)
+
+    def prepare_cv(*args, **kwargs):
+        return np.ones((3, 2), dtype=float), np.ones(3, dtype=float)
+
+    with patch.object(
+        em.np.linalg,
+        "lstsq",
+        return_value=(np.array([0.5, 1.0, -1.0], dtype=float), np.array([]), 2, np.array([])),
+    ):
+        out = method.forecast(
+            series,
+            horizon=2,
+            seasonality=1,
+            params={"methods": ["naive", "theta"], "mode": "stacking"},
+            ensemble_dispatch_method=dispatch,
+            prepare_ensemble_cv=prepare_cv,
+            get_available_methods=lambda: ("naive", "theta"),
+        )
+
+    assert np.allclose(out.forecast, [9.5, 18.5])
+    assert out.metadata["weights"] == [1.0, -1.0]
+    assert out.metadata["coefficients"] == [1.0, -1.0]
+    assert out.metadata["weight_semantics"] == "raw_coefficients"
+    assert out.metadata["intercept"] == 0.5
+
+
 def test_ensemble_reports_component_failures_from_dispatch_exceptions():
     series = pd.Series(np.linspace(1.0, 20.0, 20))
     method = em.EnsembleMethod()


### PR DESCRIPTION
## Summary
- keep stacking forecasts on their fitted regression coefficients
- stop exposing raw stacking coefficients as if they were normalized ensemble weights
- add metadata that distinguishes normalized display weights from raw stacking coefficients

## Root cause
In stacking mode, the ensemble used raw regression coefficients for prediction and then wrote those same coefficients into `metadata["weights"]`. That made stacking metadata inconsistent with average/BMA modes, where `weights` represents normalized blend weights.

## Implemented solution
- leave stacking forecast calculation unchanged on raw `coeffs`
- normalize stacking coefficients into `metadata["weights"]` when they sum to a positive finite value
- add `metadata["coefficients"]` and `metadata["weight_semantics"]` so callers can inspect the raw fitted values explicitly
- add a regression test that patches the least-squares fit and verifies forecast output, normalized metadata weights, raw coefficients, and intercept

## Trade-offs / limitations
- when stacking coefficients do not sum to a positive finite value, metadata keeps raw coefficients and marks the semantics as `raw_coefficients`
- this PR intentionally fixes metadata semantics, not the underlying stacking fit itself

## Report
- Resolves `code-reports/to-do/MED-ensemble-forecast-weights-issue.md`