### PR TITLE
core: bisect wait-event tick trimming

### DIFF
--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bisect import bisect_left
 from datetime import datetime, timedelta, timezone
 import math
 import re
@@ -2003,11 +2004,7 @@ def _trim_market_ticks(
     start_idx = 0
     if keep_seconds > 0.0:
         cutoff = observed_at_utc.timestamp() - keep_seconds - max(1.0, _MARKET_ESTIMATED_SECONDS_PER_TICK)
-        start_idx = len(ticks)
-        for idx, tick in enumerate(ticks):
-            if float(tick["epoch"]) >= cutoff:
-                start_idx = idx
-                break
+        start_idx = bisect_left(ticks, cutoff, key=lambda tick: float(tick["epoch"]))
     if keep_ticks > 0:
         start_idx = min(start_idx, max(0, len(ticks) - keep_ticks))
     return ticks[start_idx:]

--- a/tests/services/test_wait_event_use_cases.py
+++ b/tests/services/test_wait_event_use_cases.py
@@ -543,6 +543,40 @@ def test_merge_market_ticks_keeps_older_existing_keys_in_seen_set(monkeypatch) -
     assert [tick["time_msc"] for tick in merged] == [100000, 101000, 102000, 103000]
 
 
+def test_trim_market_ticks_keeps_rows_at_or_after_time_cutoff(monkeypatch) -> None:
+    monkeypatch.setattr(wait_events_mod, "_MARKET_BUFFER_EXTRA_TICKS", 0)
+    monkeypatch.setattr(wait_events_mod, "_MARKET_ESTIMATED_SECONDS_PER_TICK", 2.0)
+
+    observed_at = datetime(2026, 3, 15, 12, 0, 10, tzinfo=timezone.utc)
+    base_epoch = int(observed_at.timestamp()) - 9
+    ticks = [{"epoch": float(base_epoch + idx)} for idx in range(10)]
+
+    trimmed = wait_events_mod._trim_market_ticks(
+        ticks=ticks,
+        specs=[{"required_history_seconds": 3.0, "required_tick_count": 0}],
+        observed_at_utc=observed_at,
+    )
+
+    assert [tick["epoch"] for tick in trimmed] == [float(base_epoch + idx) for idx in range(4, 10)]
+
+
+def test_trim_market_ticks_still_honors_keep_tick_floor(monkeypatch) -> None:
+    monkeypatch.setattr(wait_events_mod, "_MARKET_BUFFER_EXTRA_TICKS", 1)
+    monkeypatch.setattr(wait_events_mod, "_MARKET_ESTIMATED_SECONDS_PER_TICK", 2.0)
+
+    observed_at = datetime(2026, 3, 15, 12, 0, 10, tzinfo=timezone.utc)
+    base_epoch = int(observed_at.timestamp()) - 9
+    ticks = [{"epoch": float(base_epoch + idx)} for idx in range(10)]
+
+    trimmed = wait_events_mod._trim_market_ticks(
+        ticks=ticks,
+        specs=[{"required_history_seconds": 1.0, "required_tick_count": 4}],
+        observed_at_utc=observed_at,
+    )
+
+    assert [tick["epoch"] for tick in trimmed] == [float(base_epoch + idx) for idx in range(5, 10)]
+
+
 def test_run_wait_event_uses_timeframe_as_boundary_when_watchers_are_inferred(monkeypatch) -> None:
     monkeypatch.setattr(
         "mtdata.core.wait_events._next_candle_wait_payload",


### PR DESCRIPTION
## Summary
- replace the linear time-cutoff scan in `_trim_market_ticks()` with a binary search over sorted tick epochs
- preserve the existing keep-ticks floor behavior after the cutoff index is found
- add focused regression tests for the time cutoff and keep-tick floor paths

## Root cause
`_trim_market_ticks()` scanned forward through every tick until it found the first epoch at or after the cutoff. Because this helper runs repeatedly while waiting on market conditions, that O(n) cutoff search added avoidable work as tick buffers grew.

## Implemented solution
- use `bisect_left(..., key=...)` directly on the sorted tick rows to find the cutoff index in log time
- leave the keep-tick floor logic unchanged so behavior stays the same once the start index is chosen
- add direct helper tests covering the time-cutoff slice and the interaction with the required-tick floor

## Trade-offs / limitations
- this optimization depends on the existing sorted-epoch invariant for normalized/merged tick rows
- the PR only changes the cutoff search; other windowing helpers in `wait_events.py` still use list filtering where appropriate

## Report
- Resolves `code-reports/to-do/MED-inefficient-candle-price-normalization.md`