### PR TITLE
services: guard null tick field access

### DIFF
--- a/src/mtdata/services/data_service.py
+++ b/src/mtdata/services/data_service.py
@@ -299,6 +299,8 @@ def _build_rates_df(rates: Any, use_client_tz: bool) -> pd.DataFrame:
 
 
 def _tick_field_value(tick: Any, name: str) -> Any:
+    if tick is None:
+        return None
     try:
         return tick[name]
     except Exception:

--- a/tests/services/test_data_service.py
+++ b/tests/services/test_data_service.py
@@ -28,7 +28,6 @@ class TestDataService(unittest.TestCase):
         from mtdata.services import data_service as data_service_mod
 
         self.assertIsNone(data_service_mod._tick_field_value(None, "bid"))
-    
     @patch('mtdata.services.data_service._mt5_copy_rates_from')
     @patch('mtdata.services.data_service._mt5_epoch_to_utc', side_effect=AssertionError("unexpected extra UTC conversion"))
     @patch('mtdata.services.data_service._symbol_ready_guard', _mock_symbol_ready_guard)

--- a/tests/services/test_data_service.py
+++ b/tests/services/test_data_service.py
@@ -23,6 +23,11 @@ def _mock_symbol_ready_guard(*args: Any, **kwargs: Any) -> Iterator[Tuple[None, 
 
 
 class TestDataService(unittest.TestCase):
+
+    def test_tick_field_value_returns_none_for_none_tick(self):
+        from mtdata.services import data_service as data_service_mod
+
+        self.assertIsNone(data_service_mod._tick_field_value(None, "bid"))
     
     @patch('mtdata.services.data_service._mt5_copy_rates_from')
     @patch('mtdata.services.data_service._mt5_epoch_to_utc', side_effect=AssertionError("unexpected extra UTC conversion"))


### PR DESCRIPTION
## Summary
- add an explicit `None` fast path to `_tick_field_value()`
- avoid the repeated exception cascade when callers pass a missing tick row
- add a direct regression test for the helper

## Root cause
`_tick_field_value()` attempted dict access, attribute access, and `.get()` access before returning `None`. When `tick` itself was `None`, the helper raised and swallowed exceptions three times before reaching the fallback.

## Implemented solution
- return `None` immediately when the incoming tick object is `None`
- keep the existing access-order behavior for non-`None` tick objects
- add a direct unit test in the existing data-service test file for the `None` case

## Trade-offs / limitations
- this PR intentionally keeps the existing broad exception structure for non-`None` objects to avoid changing the helper’s wider compatibility surface in the same patch
- the fix targets the confirmed `None` path only

## Report
- Resolves `code-reports/to-do/HIGH-null-check-tick-field.md`