### PR TITLE
services: preserve empty tick stats shape

### DIFF
--- a/src/mtdata/services/data_service.py
+++ b/src/mtdata/services/data_service.py
@@ -1224,7 +1224,27 @@ def fetch_ticks(
                 vals = vals[pd.notna(vals)].astype(float)
                 n = int(vals.shape[0])
                 if n <= 0:
-                    return {"available": False}
+                    out = {
+                        "available": False,
+                        "first": float("nan"),
+                        "last": float("nan"),
+                        "low": float("nan"),
+                        "high": float("nan"),
+                        "mean": float("nan"),
+                        "std": float("nan"),
+                        "stderr": float("nan"),
+                        "kurtosis": float("nan"),
+                        "change": float("nan"),
+                        "change_pct": float("nan"),
+                    }
+                    if detailed_stats:
+                        out["median"] = float("nan")
+                        out["skew"] = float("nan")
+                        out["q25"] = float("nan")
+                        out["q75"] = float("nan")
+                    if detailed_stats or n != int(total_count):
+                        out["count"] = n
+                    return out
                 first = float(vals.iloc[0])
                 last = float(vals.iloc[-1])
                 low = float(vals.min())

--- a/tests/services/test_data_service.py
+++ b/tests/services/test_data_service.py
@@ -1,5 +1,6 @@
 
 
+import math
 import unittest
 from unittest.mock import patch, MagicMock
 from contextlib import contextmanager
@@ -295,6 +296,55 @@ class TestDataService(unittest.TestCase):
         self.assertTrue(result.get("success"))
         self.assertEqual(result.get("spread_change_pct_note"), "first spread was zero")
         self.assertIsNone(result.get("stats", {}).get("spread", {}).get("change_pct"))
+
+    @patch('mtdata.services.data_service._mt5_copy_ticks_range')
+    @patch('mtdata.services.data_service._symbol_ready_guard', _mock_symbol_ready_guard)
+    def test_fetch_ticks_summary_keeps_empty_series_stats_shape(self, mock_copy_ticks):
+        now = datetime.now(timezone.utc).timestamp()
+        ticks = [
+            {
+                'time': now - 2,
+                'bid': float("nan"),
+                'ask': 1.1001,
+                'last': 1.10005,
+                'volume': 1.0,
+                'time_msc': (now - 2) * 1000,
+                'flags': 0,
+                'volume_real': 0.0,
+            },
+            {
+                'time': now - 1,
+                'bid': float("nan"),
+                'ask': 1.1002,
+                'last': 1.10015,
+                'volume': 1.0,
+                'time_msc': (now - 1) * 1000,
+                'flags': 0,
+                'volume_real': 0.0,
+            },
+            {
+                'time': now,
+                'bid': float("nan"),
+                'ask': 1.1003,
+                'last': 1.10025,
+                'volume': 1.0,
+                'time_msc': now * 1000,
+                'flags': 0,
+                'volume_real': 0.0,
+            },
+        ]
+        mock_copy_ticks.return_value = ticks
+
+        result = fetch_ticks(symbol="EURUSD", limit=3, output="summary")
+
+        self.assertTrue(result.get("success"))
+        bid_stats = result.get("stats", {}).get("bid", {})
+        self.assertFalse(bid_stats.get("available"))
+        for key in ("first", "last", "low", "high", "mean", "std", "stderr", "kurtosis", "change", "change_pct"):
+            self.assertIn(key, bid_stats)
+        self.assertEqual(bid_stats.get("count"), 0)
+        self.assertTrue(math.isnan(bid_stats["first"]))
+        self.assertTrue(math.isnan(bid_stats["mean"]))
 
     def test_format_candle_times_vectorizes_utc_formatting(self):
         import pandas as pd


### PR DESCRIPTION
## Summary
- fix empty-series tick stats to preserve the expected stats object shape
- add a regression for summary output when a numeric series collapses to all-NaN values

## Root cause
`fetch_ticks()` built rich stats objects for populated series, but `_series_stats()` returned only `{ "available": false }` after numeric coercion removed every value. That left successful summary responses with a different shape for empty series.

## Implemented solution
- return a full NaN-filled stats payload from `_series_stats()` when no numeric values remain
- keep `count=0` when the empty result reflects filtered-out rows or detailed stats mode
- add coverage for summary output where `bid` becomes all-NaN after coercion

## Trade-offs / limitations
- placeholder values remain `NaN` rather than `null` so downstream numeric handling stays consistent with the existing stats payload

## Report
- Resolves `code-reports/to-do/HIGH-silent-series-stats-failure.md`