### PR TITLE
services: preserve conflicting indicator names

### DIFF
--- a/src/mtdata/services/data_service.py
+++ b/src/mtdata/services/data_service.py
@@ -484,9 +484,12 @@ def _normalize_indicator_columns_for_display(
     for column in columns:
         old_name = str(column)
         new_name = _display_indicator_column_name(old_name)
-        if new_name != old_name and old_name in df.columns and new_name not in df.columns:
-            rename_map[old_name] = new_name
-        normalized.append(rename_map.get(old_name, new_name))
+        normalized_name = old_name
+        if new_name != old_name:
+            if old_name in df.columns and new_name not in df.columns and new_name not in rename_map.values():
+                rename_map[old_name] = new_name
+                normalized_name = new_name
+        normalized.append(normalized_name)
 
     if rename_map:
         df.rename(columns=rename_map, inplace=True)

--- a/tests/services/test_data_service_coverage.py
+++ b/tests/services/test_data_service_coverage.py
@@ -1002,6 +1002,43 @@ class TestFetchCandles(unittest.TestCase):
         self.assertNotIn('ATRr_14', result['data'][0])
 
     @patch(_MT5_CONFIG)
+    @patch(_APPLY_TI, return_value=['ATRr_14'])
+    @patch(_RATES_FROM)
+    @patch(_CACHED_INFO, return_value=MagicMock())
+    @patch(_RESOLVE_CTZ, return_value=None)
+    @patch(_ESTIMATE_WARMUP, return_value=20)
+    @patch(_GUARD, _mock_symbol_guard)
+    def test_indicator_display_name_conflict_preserves_actual_column_name(
+        self,
+        mock_warmup,
+        mock_ctz,
+        mock_info,
+        mock_from,
+        mock_ti,
+        mock_cfg,
+    ):
+        mock_cfg.get_time_offset_seconds.return_value = 0
+        mock_from.return_value = _make_rates(30)
+
+        def add_cols(df, spec):
+            df['ATR_14'] = 99.0
+            df['ATRr_14'] = 2.2
+            return ['ATRr_14']
+
+        mock_ti.side_effect = add_cols
+
+        result = fetch_candles('EURUSD', limit=10, indicators='ATR(14.0)')
+
+        self.assertTrue(result.get('success'))
+        self.assertEqual(
+            result['meta']['diagnostics']['indicators']['added_columns'],
+            ['ATRr_14'],
+        )
+        self.assertIn('ATRr_14', result['data'][0])
+        self.assertEqual(result['data'][0]['ATRr_14'], 2.2)
+        self.assertNotIn('ATR_14', result['data'][0])
+
+    @patch(_MT5_CONFIG)
     @patch(_RATES_FROM)
     @patch(_CACHED_INFO, return_value=MagicMock())
     @patch(_RESOLVE_CTZ, return_value=None)


### PR DESCRIPTION
## Summary
- keep indicator output column names aligned with the actual DataFrame when display-name normalization collides
- add regression coverage for the ATR display-name collision path

## Root cause
`_normalize_indicator_columns_for_display()` returned the display name even when it skipped the rename because that target column already existed. Downstream code then used the reported name and could read the conflicting existing column instead of the indicator column that was actually added.

## Implemented solution
- only return the display name when the rename is actually applied
- preserve the original column name when a collision blocks the rename
- add an end-to-end `fetch_candles()` regression covering an existing `ATR_14` plus a new `ATRr_14`

## Trade-offs / limitations
- in the collision case the API now exposes the original generated column name (`ATRr_14`) instead of forcing the prettified display name, because that is the only behavior that stays consistent with the underlying data without inventing a broader conflict-resolution policy
- `python -m pytest tests -q` currently reports an unrelated existing failure on current `origin/main`: `tests/core/test_pydantic_field_extraction_business_logic.py::test_get_pydantic_model_fields_ignores_legacy_fields`

## Report
- Resolves `code-reports/to-do/HIGH-column-conflict-validation.md`