### PR TITLE
Fix classic volume confirmation fallback without end_index

### DIFF
--- a/src/mtdata/core/patterns_support.py
+++ b/src/mtdata/core/patterns_support.py
@@ -756,7 +756,9 @@ def _attach_classic_volume_confirmation(
     bonus = _config_float(config, "volume_confirm_bonus", 0.08, minimum=0.0)
     penalty = _config_float(config, "volume_confirm_penalty", 0.06, minimum=0.0)
 
-    end_index = max(0, min(int(len(volume) - 1), int(_safe_float(out.get("end_index")) or 0)))
+    last_index = max(int(len(volume) - 1), 0)
+    raw_end_index = _safe_float(out.get("end_index"))
+    end_index = max(0, min(last_index, int(raw_end_index) if raw_end_index is not None else last_index))
     signal_start = max(0, int(end_index - breakout_bars + 1))
     baseline_end = int(signal_start - 1)
     baseline_start = max(0, int(baseline_end - lookback_bars + 1))

--- a/tests/patterns/test_patterns_core_coverage.py
+++ b/tests/patterns/test_patterns_core_coverage.py
@@ -714,6 +714,40 @@ class TestEnrichClassicPatterns:
         assert volume_confirmation["volume_source"] in {"volume", "tick_volume"}
         assert volume_confirmation["breakout_to_baseline_ratio"] > 1.2
 
+    def test_missing_end_index_uses_latest_bar_for_volume_confirmation(self):
+        from mtdata.core.patterns_support import _enrich_classic_patterns
+        from mtdata.patterns.classic import ClassicDetectorConfig
+
+        df = _make_ohlcv_df(12)
+        df["tick_volume"] = [100, 110, 105, 95, 100, 120, 130, 125, 140, 150, 320, 340]
+        rows = [
+            {
+                "name": "Ascending Triangle",
+                "status": "completed",
+                "confidence": 0.6,
+                "start_index": 2,
+                "details": {"breakout_direction": "up"},
+            }
+        ]
+
+        enriched = _enrich_classic_patterns(
+            rows,
+            df,
+            ClassicDetectorConfig(
+                volume_confirm_lookback_bars=4,
+                volume_confirm_breakout_bars=2,
+                volume_confirm_min_ratio=1.2,
+                volume_confirm_bonus=0.1,
+                volume_confirm_penalty=0.1,
+            ),
+        )
+
+        volume_confirmation = enriched[0]["details"]["volume_confirmation"]
+        assert enriched[0]["confidence"] == pytest.approx(0.7)
+        assert volume_confirmation["status"] == "confirmed"
+        assert volume_confirmation["breakout_avg_volume"] == pytest.approx(330.0)
+        assert volume_confirmation["breakout_to_baseline_ratio"] > 1.2
+
     def test_completed_targets_are_flagged_stale(self):
         from mtdata.core.patterns_support import _enrich_classic_patterns
 


### PR DESCRIPTION
## Summary
- Fix classic pattern volume confirmation when detectors omit `end_index`.
- Prevent breakout volume windows from incorrectly anchoring to the first bar of the series.

## Root cause
- `_attach_classic_volume_confirmation()` used `int(_safe_float(out.get("end_index")) or 0)`, so a missing `end_index` collapsed to `0`.

## Implemented solution
- Default missing classic-pattern `end_index` values to the latest available volume bar while still clamping explicit indices into range.
- Add a regression test covering completed classic patterns that omit `end_index`.

## Trade-offs / limitations
- The change is intentionally scoped to classic pattern volume confirmation only.
- `code-reports/*` is gitignored in this repository, so the report move to `code-reports\review\HIGH_patterns-volume-confirmation-wrong-bar.md` is local workflow state rather than part of the PR diff.

## Report
- `code-reports\to-do\HIGH_patterns-volume-confirmation-wrong-bar.md`