### PR TITLE
Fix market status holiday cache horizon

### DIFF
--- a/src/mtdata/core/market_status.py
+++ b/src/mtdata/core/market_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import holidays
@@ -108,20 +109,15 @@ _MARKETS = {
 }
 
 
-# Holiday caches per country
-_holiday_cache: Dict[str, holidays.HolidayBase] = {}
-
-
-def _get_holidays(country: str) -> holidays.HolidayBase:
-    """Get holiday calendar for a country."""
-    if country not in _holiday_cache:
-        _holiday_cache[country] = holidays.country_holidays(country, years=range(2020, 2030))
-    return _holiday_cache[country]
+@lru_cache(maxsize=64)
+def _get_holidays(country: str, year: int) -> holidays.HolidayBase:
+    """Get the holiday calendar for a country/year pair."""
+    return holidays.country_holidays(country, years=[int(year)])
 
 
 def _is_holiday(country: str, dt: datetime) -> Tuple[bool, Optional[str]]:
     """Check if date is a holiday and return holiday name if so."""
-    h = _get_holidays(country)
+    h = _get_holidays(country, dt.year)
     date_key = dt.date()
     if date_key in h:
         return True, str(h[date_key])
@@ -305,17 +301,14 @@ def _get_upcoming_holidays(market_ids: List[str], days_ahead: int = 14) -> List[
         market = _MARKETS[market_id]
         country = market["country"]
         
-        # Get holidays for this country
         try:
-            h = _get_holidays(country)
-            
             # Check next N days
             for i in range(1, days_ahead + 1):
                 check_date = now + timedelta(days=i)
                 date_key = check_date.date()
-                
-                if date_key in h:
-                    holiday_name = str(h[date_key])
+
+                is_holiday_result, holiday_name = _is_holiday(country, check_date)
+                if is_holiday_result and holiday_name is not None:
                     key = (country, date_key.isoformat())
                     
                     if key not in seen:

--- a/tests/core/test_market_status_business_logic.py
+++ b/tests/core/test_market_status_business_logic.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import mtdata.core.market_status as market_status_mod
+
+
+def test_is_holiday_loads_the_requested_year(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[int, ...]]] = []
+
+    def fake_country_holidays(country: str, years):
+        year_tuple = tuple(int(value) for value in years)
+        calls.append((country, year_tuple))
+        year = year_tuple[0]
+        return {date(year, 1, 1): f"{country}-{year}"}
+
+    market_status_mod._get_holidays.cache_clear()
+    monkeypatch.setattr(market_status_mod.holidays, "country_holidays", fake_country_holidays)
+
+    is_holiday_result, holiday_name = market_status_mod._is_holiday(
+        "US",
+        datetime(2031, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert is_holiday_result is True
+    assert holiday_name == "US-2031"
+    assert calls == [("US", (2031,))]
+
+
+def test_upcoming_holidays_crosses_into_the_next_year(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[int, ...]]] = []
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2030, 12, 30, 12, 0, tzinfo=tz or timezone.utc)
+
+    def fake_country_holidays(country: str, years):
+        year_tuple = tuple(int(value) for value in years)
+        calls.append((country, year_tuple))
+        year = year_tuple[0]
+        if year == 2031:
+            return {date(2031, 1, 1): "New Year's Day"}
+        return {}
+
+    market_status_mod._get_holidays.cache_clear()
+    monkeypatch.setattr(market_status_mod, "datetime", FixedDateTime)
+    monkeypatch.setattr(market_status_mod.holidays, "country_holidays", fake_country_holidays)
+
+    upcoming = market_status_mod._get_upcoming_holidays(["NYSE"], days_ahead=3)
+
+    assert upcoming == [
+        {
+            "date": "2031-01-01",
+            "holiday": "New Year's Day",
+            "country": "US",
+            "markets_affected": ["NYSE"],
+            "impact": "closed",
+            "early_close_time": None,
+            "days_away": 2,
+        }
+    ]
+    assert calls == [("US", (2030,)), ("US", (2031,))]


### PR DESCRIPTION
## Summary
- Replace the unbounded, static holiday cache with a bounded country/year cache.
- Keep holiday lookups working past 2030 and across year boundaries.

## Root cause
- `_get_holidays()` cached one holiday object per country forever and seeded it with the fixed range `2020..2029`, so future years were never loaded.

## Implemented solution
- Cache holiday calendars by `(country, year)` with `lru_cache(maxsize=64)`.
- Route `_is_holiday()` and `_get_upcoming_holidays()` through year-aware lookups so next-open and upcoming-holiday scans fetch the right calendar for each checked date.
- Add regression tests for direct year-specific holiday lookup and a cross-year upcoming-holidays scan.

## Trade-offs / limitations
- The fix is scoped to `market_status.py` holiday access paths.
- `code-reports/*` is gitignored in this repository, so the report move to `code-reports\review\HIGH_holiday-cache-never-expires.md` is local workflow state rather than part of the PR diff.

## Report
- `code-reports\to-do\HIGH_holiday-cache-never-expires.md`