### PR TITLE
Restrict generic MLForecast model imports

### DIFF
--- a/src/mtdata/forecast/methods/mlforecast.py
+++ b/src/mtdata/forecast/methods/mlforecast.py
@@ -232,8 +232,10 @@ class GenericMLForecastMethod(MLForecastMethod):
         try:
             sig = inspect.signature(model_cls)
             valid_params = set(sig.parameters.keys())
-        except ValueError:
-            valid_params = set()
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"Could not inspect constructor for ML model '{model_path}': {e}"
+            )
 
         model_params = {k: v for k, v in params.items() if k in valid_params}
 

--- a/src/mtdata/forecast/methods/mlforecast.py
+++ b/src/mtdata/forecast/methods/mlforecast.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+import inspect
 from typing import Any, Dict, Optional, Tuple, List
 import warnings
 import numpy as np
@@ -7,6 +9,27 @@ import pandas as pd
 
 from ..interface import ForecastMethod, ForecastResult
 from ..registry import ForecastRegistry
+
+_GENERIC_MLFORECAST_ALLOWED_MODELS = {
+    "catboost.CatBoostRegressor",
+    "lightgbm.LGBMRegressor",
+    "sklearn.ensemble.AdaBoostRegressor",
+    "sklearn.ensemble.ExtraTreesRegressor",
+    "sklearn.ensemble.GradientBoostingRegressor",
+    "sklearn.ensemble.HistGradientBoostingRegressor",
+    "sklearn.ensemble.RandomForestRegressor",
+    "sklearn.linear_model.ElasticNet",
+    "sklearn.linear_model.Lasso",
+    "sklearn.linear_model.LinearRegression",
+    "sklearn.linear_model.Ridge",
+    "sklearn.neighbors.KNeighborsRegressor",
+    "sklearn.neural_network.MLPRegressor",
+    "sklearn.svm.LinearSVR",
+    "sklearn.svm.SVR",
+    "sklearn.tree.DecisionTreeRegressor",
+    "sklearn.tree.ExtraTreeRegressor",
+    "xgboost.XGBRegressor",
+}
 
 class MLForecastMethod(ForecastMethod):
     """Base class for MLForecast methods."""
@@ -176,7 +199,7 @@ class GenericMLForecastMethod(MLForecastMethod):
     CAPABILITY_SELECTOR_MODE = "dotted_class"
 
     PARAMS: List[Dict[str, Any]] = [
-        {"name": "model", "type": "str", "description": "Dotted class path for ML model."},
+        {"name": "model", "type": "str", "description": "Approved dotted class path for ML model."},
         {"name": "lags", "type": "list", "description": "Lag features to use (auto if omitted)."},
         {"name": "rolling_agg", "type": "str|null", "description": "Rolling agg (reserved)."},
     ]
@@ -186,29 +209,34 @@ class GenericMLForecastMethod(MLForecastMethod):
         return "mlforecast"
         
     def _get_model(self, params: Dict[str, Any]):
-        model_path = params.get('model')
+        model_path = str(params.get('model') or "").strip()
         if not model_path:
             raise ValueError("GenericMLForecastMethod requires 'model' (dotted path) in params")
-            
-        # Import dynamically
+
+        if model_path not in _GENERIC_MLFORECAST_ALLOWED_MODELS:
+            allowed = ", ".join(sorted(_GENERIC_MLFORECAST_ALLOWED_MODELS))
+            raise ValueError(
+                f"Model '{model_path}' is not allowed for GenericMLForecastMethod. "
+                f"Allowed models: {allowed}"
+            )
+
         try:
             module_path, class_name = model_path.rsplit('.', 1)
-            import importlib
             module = importlib.import_module(module_path)
             model_cls = getattr(module, class_name)
-        except (ValueError, ImportError, AttributeError) as e:
-             raise ValueError(f"Could not import ML model '{model_path}': {e}")
-             
-        # Filter params
-        import inspect
+            if not inspect.isclass(model_cls):
+                raise TypeError(f"{model_path} did not resolve to a class")
+        except (TypeError, ValueError, ImportError, AttributeError) as e:
+            raise ValueError(f"Could not import ML model '{model_path}': {e}")
+
         try:
             sig = inspect.signature(model_cls)
             valid_params = set(sig.parameters.keys())
         except ValueError:
             valid_params = set()
-            
+
         model_params = {k: v for k, v in params.items() if k in valid_params}
-        
+
         return model_cls(**model_params)
 
 # Backward compatibility wrappers

--- a/tests/forecast/test_mlforecast_method_business_logic.py
+++ b/tests/forecast/test_mlforecast_method_business_logic.py
@@ -231,20 +231,25 @@ def test_generic_mlforecast_model_import_validation_and_param_filtering(monkeypa
     with pytest.raises(ValueError, match="requires 'model'"):
         method._get_model({})
 
-    with pytest.raises(ValueError, match="Could not import ML model"):
+    with pytest.raises(ValueError, match="not allowed"):
         method._get_model({"model": "missing.module.Class"})
 
-    fake_mod = ModuleType("fake_models")
+    with pytest.raises(ValueError, match="not allowed"):
+        method._get_model({"model": "fake_models.FakeModel"})
+
+    sklearn_mod = ModuleType("sklearn")
+    ensemble_mod = ModuleType("sklearn.ensemble")
 
     class FakeModel:
         def __init__(self, a, b=2):
             self.a = a
             self.b = b
 
-    fake_mod.FakeModel = FakeModel
-    monkeypatch.setitem(sys.modules, "fake_models", fake_mod)
+    ensemble_mod.RandomForestRegressor = FakeModel
+    monkeypatch.setitem(sys.modules, "sklearn", sklearn_mod)
+    monkeypatch.setitem(sys.modules, "sklearn.ensemble", ensemble_mod)
 
-    model = method._get_model({"model": "fake_models.FakeModel", "a": 5, "b": 6, "c": 7})
+    model = method._get_model({"model": "sklearn.ensemble.RandomForestRegressor", "a": 5, "b": 6, "c": 7})
     assert isinstance(model, FakeModel)
     assert model.a == 5
     assert model.b == 6

--- a/tests/forecast/test_mlforecast_method_business_logic.py
+++ b/tests/forecast/test_mlforecast_method_business_logic.py
@@ -237,6 +237,16 @@ def test_generic_mlforecast_model_import_validation_and_param_filtering(monkeypa
     with pytest.raises(ValueError, match="not allowed"):
         method._get_model({"model": "fake_models.FakeModel"})
 
+    original_import_module = mlm.importlib.import_module
+
+    def fake_import_module(name, package=None):
+        if name == "sklearn.ensemble":
+            raise ImportError("forced import failure")
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(mlm.importlib, "import_module", fake_import_module)
+    with pytest.raises(ValueError, match="Could not import ML model"):
+        method._get_model({"model": "sklearn.ensemble.RandomForestRegressor"})
     sklearn_mod = ModuleType("sklearn")
     ensemble_mod = ModuleType("sklearn.ensemble")
 


### PR DESCRIPTION
## Summary
- Restrict `GenericMLForecastMethod` to an approved set of ML model classes.
- Block arbitrary dotted imports like `os.system` while preserving the supported MLForecast regressors.

## Root cause
- `GenericMLForecastMethod._get_model()` accepted any dotted path from `params['model']`, imported the module, looked up the attribute, and instantiated it with no allowlist.

## Implemented solution
- Add an explicit allowlist of supported regression model paths for the generic MLForecast adapter.
- Reject disallowed model paths before import and keep constructor parameter filtering for allowed classes.
- Update the business-logic test to verify missing/disallowed paths fail and an approved model path still instantiates correctly.

## Trade-offs / limitations
- The fix is intentionally scoped to `GenericMLForecastMethod`; `GenericSktimeMethod` follows a similar pattern and should be reviewed separately.
- `code-reports/*` is gitignored in this repository, so the report move to `code-reports\review\HIGH_mlforecast-security-allowlist.md` is local workflow state rather than part of the PR diff.

## Report
- `code-reports\to-do\HIGH_mlforecast-security-allowlist.md`