### PR TITLE
Validate drift minimum series length

### DIFF
--- a/src/mtdata/forecast/methods/classical.py
+++ b/src/mtdata/forecast/methods/classical.py
@@ -42,6 +42,7 @@ class NaiveMethod(ClassicalMethod):
 
 @ForecastRegistry.register("drift")
 class DriftMethod(ClassicalMethod):
+    MIN_POINTS = 2
     PARAMS: List[Dict[str, Any]] = []
 
     @property
@@ -59,7 +60,11 @@ class DriftMethod(ClassicalMethod):
     ) -> ForecastResult:
         vals = series.values
         n = int(vals.size)
-        slope = (float(vals[-1]) - float(vals[0])) / float(max(1, n - 1))
+        if n < self.MIN_POINTS:
+            raise ValueError(
+                f"DriftMethod requires at least {self.MIN_POINTS} data points, got {n}"
+            )
+        slope = (float(vals[-1]) - float(vals[0])) / float(n - 1)
         f_vals = float(vals[-1]) + slope * np.arange(1, int(horizon) + 1, dtype=float)
         return ForecastResult(forecast=f_vals, params_used={"slope": slope})
 

--- a/tests/forecast/test_classical_method_business_logic.py
+++ b/tests/forecast/test_classical_method_business_logic.py
@@ -31,9 +31,11 @@ def test_naive_and_drift_forecasts_return_expected_values():
     assert np.allclose(drift.forecast, [17.5, 20.0, 22.5])
     assert drift.params_used == {"slope": 2.5}
 
-    single = cl.DriftMethod().forecast(pd.Series([5.0]), horizon=2, seasonality=0, params={})
-    assert np.allclose(single.forecast, [5.0, 5.0])
-    assert single.params_used == {"slope": 0.0}
+    with pytest.raises(ValueError, match="requires at least 2 data points"):
+        cl.DriftMethod().forecast(pd.Series([5.0]), horizon=2, seasonality=0, params={})
+
+    with pytest.raises(ValueError, match="requires at least 2 data points"):
+        cl.DriftMethod().forecast(pd.Series(dtype=float), horizon=2, seasonality=0, params={})
 
 
 def test_seasonal_naive_validation_and_repeating_pattern():


### PR DESCRIPTION
## Summary
- fix `DriftMethod` so it rejects empty and single-point series instead of silently producing a flat forecast
- update the focused classical forecast test to cover both undersized-input paths

## Root cause
`DriftMethod.forecast()` used `max(1, n - 1)` to avoid literal division by zero, but that also treated `n < 2` as valid input. That let empty input fail indirectly with indexing errors and let single-point input return a zero-slope forecast even though drift is undefined without at least two observations.

## Implemented solution
- add an explicit two-point minimum validation in `DriftMethod`
- remove the defensive `max(1, ...)` fallback once the precondition is enforced
- update regression coverage to assert the clear `ValueError` for one-point and empty series

## Trade-offs / limitations
This changes undersized drift input from a silent flat forecast to an explicit error. Callers that want flat fallback behavior should use `naive` directly rather than relying on undefined drift semantics.

## Report
Resolves local report `code-reports/to-do/MED_drift-single-point-undefined.md`.