### PR TITLE
Validate backtest anchor spacing

### DIFF
--- a/src/mtdata/forecast/backtest.py
+++ b/src/mtdata/forecast/backtest.py
@@ -162,6 +162,14 @@ def forecast_backtest(
         include_paths = detail_mode == "full"
         if timeframe not in TIMEFRAME_MAP:
             return {"error": invalid_timeframe_error(timeframe, TIMEFRAME_MAP)}
+        if (
+            not anchors
+            and int(steps) > 1
+            and int(spacing) < int(horizon)
+        ):
+            return {
+                "error": "spacing must be greater than or equal to horizon when steps > 1"
+            }
 
         # Fetch sufficient history via shared helper; ensure enough bars for anchors
         if anchors and isinstance(anchors, (list, tuple)) and len(anchors) > 0:

--- a/tests/forecast/test_backtest_extended.py
+++ b/tests/forecast/test_backtest_extended.py
@@ -202,16 +202,16 @@ class TestForecastBacktest:
                 timeframe="H1",
                 horizon=12,
                 steps=2,
-                spacing=10,
+                spacing=12,
                 methods=["theta"],
             )
 
         assert result.get("success") is True
         assert captured == [
             {
-                "as_of": _format_time_minimal(float(df["time"].iloc[477])),
-                "prefetched_len": 478,
-                "prefetched_last_time": float(df["time"].iloc[477]),
+                "as_of": _format_time_minimal(float(df["time"].iloc[475])),
+                "prefetched_len": 476,
+                "prefetched_last_time": float(df["time"].iloc[475]),
             },
             {
                 "as_of": _format_time_minimal(float(df["time"].iloc[487])),
@@ -219,6 +219,22 @@ class TestForecastBacktest:
                 "prefetched_last_time": float(df["time"].iloc[487]),
             },
         ]
+
+    @patch("mtdata.forecast.backtest._fetch_history")
+    def test_rejects_overlapping_generated_backtest_windows(self, fetch):
+        result = forecast_backtest(
+            "EURUSD",
+            timeframe="H1",
+            horizon=12,
+            steps=2,
+            spacing=10,
+            methods=["theta"],
+        )
+
+        assert result == {
+            "error": "spacing must be greater than or equal to horizon when steps > 1"
+        }
+        fetch.assert_not_called()
 
     @patch("mtdata.forecast.backtest._fetch_history")
     def test_explicit_anchors(self, fetch):


### PR DESCRIPTION
## Summary
- reject rolling backtests that would generate overlapping evaluation windows because `spacing < horizon`
- keep the existing nested-forecast anchor-history test but move it to a valid non-overlapping spacing
- add a regression test proving the invalid overlap case is rejected before any history fetch runs

## Root cause
`forecast_backtest()` generated automatic anchor indices by subtracting `spacing`, but later each anchor trained on `df.iloc[: idx + 1]`. When `steps > 1` and `spacing < horizon`, bars that belonged to one anchor's evaluation window were already inside the next anchor's training slice, which leaks future information across walk-forward windows.

## Implemented solution
- add an explicit guard in `mtdata.forecast.backtest.forecast_backtest()` for auto-generated multi-step anchors where `spacing < horizon`
- preserve single-step and explicit-anchor flows, since they do not create the same rolling overlap automatically
- update focused backtest coverage to assert the new error path and to keep the prefetched-history behavior covered under a valid spacing

## Trade-offs / limitations
This change rejects overlapping auto-generated backtests instead of trying to reinterpret them. Explicit `anchors` remain caller-controlled; if a caller passes overlapping anchor timestamps manually, this fix does not attempt to normalize or reject them.

## Report
Resolves local report `code-reports/to-do/HIGH_backtest-spacing-validation.md`.