### PR TITLE
Guard GBM barrier probability underflow

### DIFF
--- a/src/mtdata/forecast/monte_carlo.py
+++ b/src/mtdata/forecast/monte_carlo.py
@@ -738,21 +738,28 @@ def gbm_single_barrier_upcross_prob(
     if T_f <= 0.0:
         return 0.0
 
+    x0 = math.log(s0_f)
+    a = math.log(barrier_f)
+
     # Deterministic limiting case.
     if sigma_f <= 0.0:
         if mu_f <= 0.0:
             return 0.0
-        return 1.0 if (s0_f * math.exp(mu_f * T_f) >= barrier_f) else 0.0
+        return 1.0 if (x0 + mu_f * T_f >= a) else 0.0
+
+    sigma_var = sigma_f * sigma_f
+    m = mu_f - 0.5 * sigma_var
+    srt = sigma_f * math.sqrt(T_f)
+    if srt <= 0.0 or sigma_var <= 0.0:
+        if mu_f <= 0.0:
+            return 0.0
+        return 1.0 if (x0 + mu_f * T_f >= a) else 0.0
 
     from scipy.stats import norm
 
-    x0 = math.log(s0_f)
-    a = math.log(barrier_f)
-    m = mu_f - 0.5 * sigma_f * sigma_f
-    srt = sigma_f * math.sqrt(T_f)
     z1 = (x0 - a + m * T_f) / srt
     z2 = (x0 - a - m * T_f) / srt
-    log_term = 2.0 * m * (a - x0) / (sigma_f * sigma_f)
+    log_term = 2.0 * m * (a - x0) / sigma_var
     log_second_term = float(log_term + norm.logcdf(z2))
     if log_second_term <= -745.0:
         second_term = 0.0

--- a/tests/forecast/test_monte_carlo_pure.py
+++ b/tests/forecast/test_monte_carlo_pure.py
@@ -381,6 +381,14 @@ class TestGbmBarrierUpcrossProb:
         p = gbm_single_barrier_upcross_prob(100.0, 200.0, 0.1, 0.0, 1.0)
         assert p == 0.0
 
+    def test_tiny_positive_sigma_and_time_underflow_to_deterministic_no_reach(self):
+        p = gbm_single_barrier_upcross_prob(100.0, 110.0, 0.05, 5e-324, 5e-324)
+        assert p == 0.0
+
+    def test_tiny_positive_sigma_squared_underflow_uses_deterministic_limit(self):
+        p = gbm_single_barrier_upcross_prob(100.0, 101.0, 0.05, 1e-200, 1.0)
+        assert p == 1.0
+
     def test_invalid_inputs(self):
         assert gbm_single_barrier_upcross_prob(0.0, 100.0, 0.05, 0.2, 1.0) == 0.0
         assert gbm_single_barrier_upcross_prob(100.0, 110.0, 0.05, 0.2, 0.0) == 0.0


### PR DESCRIPTION
## Summary
- guard `gbm_single_barrier_upcross_prob()` against tiny-positive diffusion inputs that underflow its denominators to zero
- keep the existing exact-zero deterministic behavior while extending it to numerically equivalent underflow cases
- add focused regressions for both `sigma * sqrt(T)` underflow and `sigma**2` underflow

## Root cause
The helper already returned early for exact `sigma <= 0` and `T <= 0`, but it assumed tiny positive inputs would still produce nonzero denominators. In practice, very small positive `sigma`, `T`, or both can underflow `sigma * sqrt(T)` or `sigma**2` to `0.0`, which caused `ZeroDivisionError` before the probability clamp ran.

## Implemented solution
- compute the log-price barrier comparison once up front
- reuse the deterministic-limit branch when the derived diffusion terms underflow to zero, not just when `sigma <= 0`
- switch the deterministic branch to a log-space comparison so it does not rely on `exp()` growth to compare against the barrier
- extend `test_monte_carlo_pure.py` with regressions for both tiny-positive underflow scenarios

## Trade-offs / limitations
This fix treats underflowed diffusion as the deterministic limit, which is the numerically stable continuation of the existing exact-zero branch. It does not otherwise change the closed-form barrier formula for ordinary positive-volatility inputs.

## Report
Resolves local report `code-reports/to-do/MED_gbm-barrier-div-by-zero.md`.