### PR TITLE
Validate HNS neckline geometry

### DIFF
--- a/src/mtdata/patterns/classic_impl/reversal.py
+++ b/src/mtdata/patterns/classic_impl/reversal.py
@@ -197,6 +197,7 @@ def detect_head_shoulders(
         sh_avg = (ls_p + rs_p) / 2.0
         if sh_avg == 0.0:
             return
+        shoulder_eps = max(1e-9, abs(sh_avg) * 1e-9)
         head_prom = (
             (head_price - sh_avg) / abs(sh_avg) * 100.0
             if regular
@@ -204,6 +205,22 @@ def detect_head_shoulders(
         )
         if head_prom < max(1.0, tol_pct):
             return
+        left_neck_at_shoulder = float(slope * float(lsh) + intercept)
+        right_neck_at_shoulder = float(slope * float(rsh) + intercept)
+        if not np.isfinite(left_neck_at_shoulder) or not np.isfinite(right_neck_at_shoulder):
+            return
+        if regular:
+            if (
+                left_neck_at_shoulder >= (ls_p + shoulder_eps)
+                or right_neck_at_shoulder >= (rs_p + shoulder_eps)
+            ):
+                return
+        else:
+            if (
+                left_neck_at_shoulder <= (ls_p - shoulder_eps)
+                or right_neck_at_shoulder <= (rs_p - shoulder_eps)
+            ):
+                return
 
         status = 'forming'
         name = 'Head and Shoulders' if regular else 'Inverse Head and Shoulders'

--- a/tests/patterns/test_pattern_detection_behaviors.py
+++ b/tests/patterns/test_pattern_detection_behaviors.py
@@ -2203,6 +2203,42 @@ def test_detect_inverse_head_shoulders_uses_reaction_peaks_for_neckline(monkeypa
     assert inverse.details["neck_points"] == 2
 
 
+def test_detect_head_shoulders_rejects_neckline_above_shoulders():
+    from src.mtdata.patterns.classic_impl import reversal
+
+    close = np.array([96.0, 100.0, 101.0, 103.0, 110.0, 101.5, 101.2, 99.0, 100.5, 97.0], dtype=float)
+    peaks = np.array([1, 4, 8], dtype=int)
+    troughs = np.array([2, 5, 6], dtype=int)
+
+    out = reversal.detect_head_shoulders(
+        close,
+        peaks,
+        troughs,
+        np.arange(close.size, dtype=float),
+        ClassicDetectorConfig(same_level_tol_pct=1.0, use_dtw_check=False, use_robust_fit=False),
+    )
+
+    assert out == []
+
+
+def test_detect_inverse_head_shoulders_rejects_neckline_below_shoulders():
+    from src.mtdata.patterns.classic_impl import reversal
+
+    close = np.array([104.0, 95.0, 94.0, 90.0, 94.5, 96.0, 108.0], dtype=float)
+    peaks = np.array([0, 2, 4, 6], dtype=int)
+    troughs = np.array([1, 3, 5], dtype=int)
+
+    out = reversal.detect_head_shoulders(
+        close,
+        peaks,
+        troughs,
+        np.arange(close.size, dtype=float),
+        ClassicDetectorConfig(same_level_tol_pct=2.0, use_dtw_check=False, use_robust_fit=False),
+    )
+
+    assert out == []
+
+
 def test_head_shoulders_two_point_neckline_does_not_get_free_r2_boost():
     from src.mtdata.patterns.classic_impl import reversal
 


### PR DESCRIPTION
## Summary
- reject head-and-shoulders candidates when the fitted neckline sits on the wrong side of either shoulder
- cover both the regular and inverse branches with regressions that previously produced geometrically invalid patterns

## Root cause
`detect_head_shoulders()` chose reaction pivots by index and fit a neckline through them, but it never validated the resulting line against the shoulder prices. That let obviously invalid candidates through when the selected reaction troughs/peaks implied a neckline above regular shoulders or below inverse shoulders.

## Implemented solution
- evaluate the fitted neckline at the left and right shoulder indices
- reject regular patterns whose neckline is not below both shoulders and inverse patterns whose neckline is not above both shoulders
- add regression tests using real fitted necklines for both invalid geometries

## Trade-offs / limitations
This change only validates the neckline against the selected shoulder endpoints; it does not try to reinterpret or repair bad pivot choices. Candidates that fail the geometry check are simply discarded, which keeps the detector behavior conservative.

## Report
Resolves local report `code-reports/to-do/MED_hns-neckline-price-validation-missing.md`.