### PR TITLE
Validate rolling feature window sizes

### DIFF
--- a/src/mtdata/core/features.py
+++ b/src/mtdata/core/features.py
@@ -1,3 +1,5 @@
+import numbers
+
 import numpy as np
 import pandas as pd
 import warnings
@@ -6,13 +8,20 @@ import warnings
 def _normalize_window_size(window_size: int) -> int:
     if isinstance(window_size, (bool, np.bool_)):
         raise ValueError("window_size must be a positive integer")
-    try:
-        window_size_f = float(window_size)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("window_size must be a positive integer") from exc
-    if not window_size_f.is_integer():
-        raise ValueError("window_size must be a positive integer")
-    window_size_i = int(window_size_f)
+    if isinstance(window_size, numbers.Integral):
+        window_size_i = int(window_size)
+    elif isinstance(window_size, float):
+        if not window_size.is_integer():
+            raise ValueError("window_size must be a positive integer")
+        window_size_i = int(window_size)
+    else:
+        try:
+            window_size_f = float(window_size)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("window_size must be a positive integer") from exc
+        if not window_size_f.is_integer():
+            raise ValueError("window_size must be a positive integer")
+        window_size_i = int(window_size_f)
     if window_size_i <= 0:
         raise ValueError("window_size must be a positive integer")
     return window_size_i

--- a/src/mtdata/core/features.py
+++ b/src/mtdata/core/features.py
@@ -4,7 +4,7 @@ import warnings
 
 
 def _normalize_window_size(window_size: int) -> int:
-    if isinstance(window_size, bool):
+    if isinstance(window_size, (bool, np.bool_)):
         raise ValueError("window_size must be a positive integer")
     try:
         window_size_f = float(window_size)

--- a/src/mtdata/core/features.py
+++ b/src/mtdata/core/features.py
@@ -2,6 +2,22 @@ import numpy as np
 import pandas as pd
 import warnings
 
+
+def _normalize_window_size(window_size: int) -> int:
+    if isinstance(window_size, bool):
+        raise ValueError("window_size must be a positive integer")
+    try:
+        window_size_f = float(window_size)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("window_size must be a positive integer") from exc
+    if not window_size_f.is_integer():
+        raise ValueError("window_size must be a positive integer")
+    window_size_i = int(window_size_f)
+    if window_size_i <= 0:
+        raise ValueError("window_size must be a positive integer")
+    return window_size_i
+
+
 def extract_rolling_features(
     series: np.ndarray, 
     window_size: int = 20, 
@@ -19,6 +35,7 @@ def extract_rolling_features(
         DataFrame where each row corresponds to the features of the window ending at that index.
         The index of the DataFrame aligns with the input series (rows < window_size will be NaN/imputed).
     """
+    window_size = _normalize_window_size(window_size)
     try:
         from tsfresh import extract_features
         from tsfresh.utilities.dataframe_functions import roll_time_series
@@ -29,11 +46,10 @@ def extract_rolling_features(
     # Convert to standard format expected by tsfresh
     # series needs to be a DataFrame with "id", "time", "value"
     # For rolling, we use roll_time_series which creates a new ID for each window.
-    
     n = len(series)
     if n < window_size:
         return pd.DataFrame() # Not enough data
-        
+
     df = pd.DataFrame({
         "id": np.ones(n, dtype=int),
         "time": np.arange(n),

--- a/tests/core/test_features_business_logic.py
+++ b/tests/core/test_features_business_logic.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import sys
+import types
+
+from mtdata.core.features import extract_rolling_features
+
+
+@pytest.mark.parametrize("window_size", [0, -1, 2.5, True])
+def test_extract_rolling_features_rejects_invalid_window_size(window_size):
+    with pytest.raises(ValueError, match="window_size must be a positive integer"):
+        extract_rolling_features(np.array([1.0, 2.0, 3.0]), window_size=window_size)
+
+
+def test_extract_rolling_features_returns_empty_for_short_series(monkeypatch):
+    fake = types.SimpleNamespace(extract_features=lambda *args, **kwargs: pd.DataFrame())
+    feature_extraction = types.SimpleNamespace(
+        EfficientFCParameters=lambda: {"eff": None},
+        MinimalFCParameters=lambda: {"min": None},
+    )
+    dataframe_functions = types.SimpleNamespace(
+        roll_time_series=lambda *args, **kwargs: pd.DataFrame()
+    )
+    monkeypatch.setitem(sys.modules, "tsfresh", fake)
+    monkeypatch.setitem(sys.modules, "tsfresh.feature_extraction", feature_extraction)
+    monkeypatch.setitem(sys.modules, "tsfresh.utilities.dataframe_functions", dataframe_functions)
+
+    out = extract_rolling_features(np.array([1.0, 2.0, 3.0]), window_size=5)
+
+    assert isinstance(out, pd.DataFrame)
+    assert out.empty

--- a/tests/core/test_features_business_logic.py
+++ b/tests/core/test_features_business_logic.py
@@ -16,16 +16,23 @@ def test_extract_rolling_features_rejects_invalid_window_size(window_size):
 
 
 def test_extract_rolling_features_returns_empty_for_short_series(monkeypatch):
-    fake = types.SimpleNamespace(extract_features=lambda *args, **kwargs: pd.DataFrame())
-    feature_extraction = types.SimpleNamespace(
-        EfficientFCParameters=lambda: {"eff": None},
-        MinimalFCParameters=lambda: {"min": None},
-    )
-    dataframe_functions = types.SimpleNamespace(
-        roll_time_series=lambda *args, **kwargs: pd.DataFrame()
-    )
-    monkeypatch.setitem(sys.modules, "tsfresh", fake)
+    tsfresh = types.ModuleType("tsfresh")
+    tsfresh.__path__ = []
+    tsfresh.extract_features = lambda *args, **kwargs: pd.DataFrame()
+
+    feature_extraction = types.ModuleType("tsfresh.feature_extraction")
+    feature_extraction.EfficientFCParameters = lambda: {"eff": None}
+    feature_extraction.MinimalFCParameters = lambda: {"min": None}
+
+    utilities = types.ModuleType("tsfresh.utilities")
+    utilities.__path__ = []
+
+    dataframe_functions = types.ModuleType("tsfresh.utilities.dataframe_functions")
+    dataframe_functions.roll_time_series = lambda *args, **kwargs: pd.DataFrame()
+
+    monkeypatch.setitem(sys.modules, "tsfresh", tsfresh)
     monkeypatch.setitem(sys.modules, "tsfresh.feature_extraction", feature_extraction)
+    monkeypatch.setitem(sys.modules, "tsfresh.utilities", utilities)
     monkeypatch.setitem(sys.modules, "tsfresh.utilities.dataframe_functions", dataframe_functions)
 
     out = extract_rolling_features(np.array([1.0, 2.0, 3.0]), window_size=5)


### PR DESCRIPTION
## Summary
- validate `extract_rolling_features()` window sizes before calling into `tsfresh`
- keep the existing empty-DataFrame behavior for valid-but-undersized series
- add direct regression coverage for invalid window sizes and the short-series contract

## Root cause
`extract_rolling_features()` only compared `len(series)` to `window_size`. That meant `0`, negative, boolean, and non-integer window sizes could flow through into the rolling extraction setup, producing silent or confusing behavior instead of a clear caller error.

## Implemented solution
- add `_normalize_window_size()` to require a positive integer window size
- run that validation before the `tsfresh` import so invalid input fails deterministically
- preserve the existing `pd.DataFrame()` return for valid windows that exceed the available series length
- add focused tests for invalid window sizes and the short-series path

## Trade-offs / limitations
This fix intentionally does not introduce an arbitrary maximum window-size cap, because the codebase has no existing threshold to reuse and changing that policy would be broader than the validated defect. It also preserves the prior empty-result behavior for short but otherwise valid series so regime detection keeps surfacing its existing friendly error path.

## Report
Resolves local report `code-reports/to-do/MED_missing-window-size-validation.md`.