### PR TITLE
Precompute wait-event watcher requirements

### DIFF
--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -40,6 +40,9 @@ _MARKET_BUFFER_EXTRA_TICKS = 32
 _ACCOUNT_HISTORY_SEED_LOOKBACK_SECONDS = 5.0
 _ORDER_STATE_EVENT_TYPES = {"order_created", "pending_near_fill"}
 _POSITION_STATE_EVENT_TYPES = {"position_opened", "position_closed", "stop_threat"}
+_ORDER_POSITION_EVENT_TYPES = _ORDER_STATE_EVENT_TYPES | _POSITION_STATE_EVENT_TYPES
+_HISTORY_DEAL_EVENT_TYPES = {"order_filled", "position_opened", "position_closed", "tp_hit", "sl_hit"}
+_HISTORY_ORDER_EVENT_TYPES = {"order_cancelled"}
 _MARKET_EVENT_TYPES = {
     "price_change",
     "volume_spike",
@@ -83,6 +86,12 @@ def run_wait_event_loop(
     end_on_inferred = bool(compiled.get("end_on_inferred"))
     watch_for_payload = list(compiled.get("watch_for_payload", []))
     end_on_payload = list(compiled.get("end_on_payload", []))
+    needs_orders = bool(compiled.get("needs_orders"))
+    needs_positions = bool(compiled.get("needs_positions"))
+    needs_current_state = bool(compiled.get("needs_current_state"))
+    needs_history_deals = bool(compiled.get("needs_history_deals"))
+    needs_history_orders = bool(compiled.get("needs_history_orders"))
+    market_specs = list(compiled.get("market_specs", []))
     max_wait_seconds = (
         None if request.max_wait_seconds is None else float(request.max_wait_seconds)
     )
@@ -101,16 +110,25 @@ def run_wait_event_loop(
 
     history_state = _build_account_history_state(
         gateway=gateway,
-        watch_for=watch_for,
+        needs_history_deals=needs_history_deals,
+        needs_history_orders=needs_history_orders,
         started_at_utc=started_at_utc,
     )
     if isinstance(history_state, dict) and "error" in history_state:
         return history_state
 
-    baseline = _build_baseline(gateway, watch_for) if _watchers_need_current_state(watch_for) else {}
+    baseline = (
+        _build_baseline(
+            gateway,
+            needs_orders=needs_orders,
+            needs_positions=needs_positions,
+        )
+        if needs_current_state
+        else {}
+    )
     market_state = _build_market_state(
         gateway=gateway,
-        watch_for=watch_for,
+        market_specs=market_specs,
         observed_at_utc=started_at_utc,
         poll_interval_seconds=poll_interval_seconds,
     )
@@ -149,12 +167,16 @@ def run_wait_event_loop(
             return connection_error
         snapshot = _collect_snapshot(
             gateway=gateway,
-            watch_for=watch_for,
             baseline=baseline,
             history_state=history_state,
             market_state=market_state,
             started_at_utc=started_at_utc,
             observed_at_utc=observed_at_utc,
+            needs_orders=needs_orders,
+            needs_positions=needs_positions,
+            needs_history_deals=needs_history_deals,
+            needs_history_orders=needs_history_orders,
+            market_specs=market_specs,
         )
         if "error" in snapshot:
             return snapshot
@@ -258,6 +280,8 @@ def _compile_request(
             return compiled
         end_on.append(compiled)
 
+    watcher_requirements = _watcher_requirements(watch_for)
+
     return {
         "watch_for": watch_for,
         "watch_for_inferred": watch_for_inferred,
@@ -271,6 +295,7 @@ def _compile_request(
             ),
         ),
         "end_on_payload": [_public_boundary_spec_payload(spec, request=request) for spec in source_end_specs],
+        **watcher_requirements,
     }
 
 
@@ -576,38 +601,69 @@ def _run_candle_boundary_only(
     return payload
 
 
-def _build_baseline(gateway: Any, watch_for: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _watcher_requirements(watch_for: List[Dict[str, Any]]) -> Dict[str, Any]:
+    market_specs: List[Dict[str, Any]] = []
+    needs_orders = False
+    needs_positions = False
+    needs_history_deals = False
+    needs_history_orders = False
+    for item in watch_for:
+        event_type = str(item["type"])
+        if event_type in _ORDER_STATE_EVENT_TYPES:
+            needs_orders = True
+        if event_type in _POSITION_STATE_EVENT_TYPES:
+            needs_positions = True
+        if event_type in _HISTORY_DEAL_EVENT_TYPES:
+            needs_history_deals = True
+        if event_type in _HISTORY_ORDER_EVENT_TYPES:
+            needs_history_orders = True
+        if event_type in _MARKET_EVENT_TYPES:
+            market_specs.append(item)
+    return {
+        "needs_orders": needs_orders,
+        "needs_positions": needs_positions,
+        "needs_current_state": needs_orders or needs_positions,
+        "needs_history_deals": needs_history_deals,
+        "needs_history_orders": needs_history_orders,
+        "market_specs": market_specs,
+    }
+
+
+def _build_baseline(
+    gateway: Any,
+    *,
+    needs_orders: bool,
+    needs_positions: bool,
+) -> Dict[str, Any]:
     baseline: Dict[str, Any] = {}
-    if any(item["type"] in _ORDER_STATE_EVENT_TYPES for item in watch_for):
+    if needs_orders:
         baseline["orders"] = _coerce_rows(gateway.orders_get())
-    if any(item["type"] in _POSITION_STATE_EVENT_TYPES for item in watch_for):
+    if needs_positions:
         baseline["positions"] = _coerce_rows(gateway.positions_get())
     return baseline
 
 
 def _watchers_need_current_state(watch_for: List[Dict[str, Any]]) -> bool:
-    return any(item["type"] in (_ORDER_STATE_EVENT_TYPES | _POSITION_STATE_EVENT_TYPES) for item in watch_for)
+    return any(item["type"] in _ORDER_POSITION_EVENT_TYPES for item in watch_for)
 
 
 def _watchers_need_history_deals(watch_for: List[Dict[str, Any]]) -> bool:
-    return any(
-        item["type"] in {"order_filled", "position_opened", "position_closed", "tp_hit", "sl_hit"}
-        for item in watch_for
-    )
+    return any(item["type"] in _HISTORY_DEAL_EVENT_TYPES for item in watch_for)
 
 
 def _watchers_need_history_orders(watch_for: List[Dict[str, Any]]) -> bool:
-    return any(item["type"] == "order_cancelled" for item in watch_for)
+    return any(item["type"] in _HISTORY_ORDER_EVENT_TYPES for item in watch_for)
 
 
 def _build_account_history_state(
     *,
     gateway: Any,
-    watch_for: List[Dict[str, Any]],
+    needs_history_deals: bool,
+    needs_history_orders: bool,
     started_at_utc: datetime,
 ) -> Dict[str, Any]:
     state: Dict[str, Any] = {}
-    if _watchers_need_history_deals(watch_for):
+    if needs_history_deals:
         seeded = _seed_account_history_keys(
             fetch_impl=gateway.history_deals_get,
             started_at_utc=started_at_utc,
@@ -617,7 +673,7 @@ def _build_account_history_state(
         if isinstance(seeded, dict) and "error" in seeded:
             return seeded
         state["history_deals"] = {"seen_keys": seeded}
-    if _watchers_need_history_orders(watch_for):
+    if needs_history_orders:
         seeded = _seed_account_history_keys(
             fetch_impl=gateway.history_orders_get,
             started_at_utc=started_at_utc,
@@ -704,31 +760,35 @@ def _find_preexisting_match(
 def _collect_snapshot(
     *,
     gateway: Any,
-    watch_for: List[Dict[str, Any]],
     baseline: Dict[str, Any],
     history_state: Dict[str, Any],
     market_state: Dict[str, Any],
     started_at_utc: datetime,
     observed_at_utc: datetime,
+    needs_orders: bool,
+    needs_positions: bool,
+    needs_history_deals: bool,
+    needs_history_orders: bool,
+    market_specs: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
     snapshot: Dict[str, Any] = {
         "observed_at_utc": observed_at_utc,
         "baseline": baseline,
     }
 
-    if any(item["type"] in _ORDER_STATE_EVENT_TYPES for item in watch_for):
+    if needs_orders:
         try:
             snapshot["orders"] = _coerce_rows(gateway.orders_get())
         except Exception as exc:
             return {"error": f"Failed to fetch open orders: {exc}"}
 
-    if any(item["type"] in _POSITION_STATE_EVENT_TYPES for item in watch_for):
+    if needs_positions:
         try:
             snapshot["positions"] = _coerce_rows(gateway.positions_get())
         except Exception as exc:
             return {"error": f"Failed to fetch open positions: {exc}"}
 
-    if _watchers_need_history_deals(watch_for):
+    if needs_history_deals:
         rows = _collect_new_account_history_rows(
             fetch_impl=gateway.history_deals_get,
             started_at_utc=started_at_utc,
@@ -741,7 +801,7 @@ def _collect_snapshot(
             return rows
         snapshot["history_deals"] = rows
 
-    if _watchers_need_history_orders(watch_for):
+    if needs_history_orders:
         rows = _collect_new_account_history_rows(
             fetch_impl=gateway.history_orders_get,
             started_at_utc=started_at_utc,
@@ -754,12 +814,11 @@ def _collect_snapshot(
             return rows
         snapshot["history_orders"] = rows
 
-    market_specs = [item for item in watch_for if item["type"] in _MARKET_EVENT_TYPES]
     if market_specs:
         refreshed = _refresh_market_state(
             market_state=market_state,
             gateway=gateway,
-            watch_for=market_specs,
+            market_specs=market_specs,
             observed_at_utc=observed_at_utc,
         )
         if isinstance(refreshed, dict) and "error" in refreshed:
@@ -813,11 +872,10 @@ def _collect_new_account_history_rows(
 def _build_market_state(
     *,
     gateway: Any,
-    watch_for: List[Dict[str, Any]],
+    market_specs: List[Dict[str, Any]],
     observed_at_utc: datetime,
     poll_interval_seconds: float,
 ) -> Dict[str, Any]:
-    market_specs = [item for item in watch_for if item["type"] in _MARKET_EVENT_TYPES]
     if not market_specs:
         return {}
 
@@ -841,10 +899,10 @@ def _refresh_market_state(
     *,
     market_state: Dict[str, Any],
     gateway: Any,
-    watch_for: List[Dict[str, Any]],
+    market_specs: List[Dict[str, Any]],
     observed_at_utc: datetime,
 ) -> Dict[str, Any]:
-    for symbol in _market_symbols(watch_for):
+    for symbol in _market_symbols(market_specs):
         state = market_state.get(symbol)
         if state is None:
             continue
@@ -861,7 +919,7 @@ def _refresh_market_state(
         trimmed = _merge_market_ticks(
             state.get("ticks", []),
             ticks_or_error,
-            specs=[item for item in watch_for if item["symbol"] == symbol],
+            specs=[item for item in market_specs if item["symbol"] == symbol],
             observed_at_utc=observed_at_utc,
         )
         state["ticks"] = trimmed

--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -643,18 +643,6 @@ def _build_baseline(
     return baseline
 
 
-def _watchers_need_current_state(watch_for: List[Dict[str, Any]]) -> bool:
-    return any(item["type"] in _ORDER_POSITION_EVENT_TYPES for item in watch_for)
-
-
-def _watchers_need_history_deals(watch_for: List[Dict[str, Any]]) -> bool:
-    return any(item["type"] in _HISTORY_DEAL_EVENT_TYPES for item in watch_for)
-
-
-def _watchers_need_history_orders(watch_for: List[Dict[str, Any]]) -> bool:
-    return any(item["type"] in _HISTORY_ORDER_EVENT_TYPES for item in watch_for)
-
-
 def _build_account_history_state(
     *,
     gateway: Any,

--- a/tests/core/test_wait_events_business_logic.py
+++ b/tests/core/test_wait_events_business_logic.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from mtdata.core.data_requests import WaitEventRequest
+from mtdata.core import wait_events
+
+
+def test_compile_request_precomputes_waiter_requirements() -> None:
+    request = WaitEventRequest.model_validate(
+        {
+            "symbol": "EURUSD",
+            "watch_for": [
+                {"type": "pending_near_fill", "distance": 0.2},
+                {"type": "order_cancelled"},
+                {"type": "position_closed"},
+                {
+                    "type": "price_change",
+                    "window": {"kind": "ticks", "value": 5},
+                    "baseline_window": {"kind": "ticks", "value": 20},
+                    "threshold_mode": "ratio_to_baseline",
+                    "threshold_value": 3.0,
+                },
+            ],
+        }
+    )
+
+    compiled = wait_events._compile_request(
+        request,
+        started_at_utc=datetime(2026, 4, 5, tzinfo=timezone.utc),
+    )
+
+    assert compiled["needs_orders"] is True
+    assert compiled["needs_positions"] is True
+    assert compiled["needs_current_state"] is True
+    assert compiled["needs_history_deals"] is True
+    assert compiled["needs_history_orders"] is True
+    assert [item["type"] for item in compiled["market_specs"]] == [
+        "pending_near_fill",
+        "price_change",
+    ]
+
+
+def test_collect_snapshot_uses_precomputed_market_specs(monkeypatch) -> None:
+    captured = {}
+
+    class Gateway:
+        def orders_get(self):  # pragma: no cover - should not be called
+            raise AssertionError("orders_get should not be called")
+
+        def positions_get(self):  # pragma: no cover - should not be called
+            raise AssertionError("positions_get should not be called")
+
+    def fake_refresh_market_state(*, market_state, gateway, market_specs, observed_at_utc):
+        captured["market_specs"] = market_specs
+        return {"EURUSD": {"last_epoch": observed_at_utc.timestamp(), "ticks": []}}
+
+    monkeypatch.setattr(wait_events, "_refresh_market_state", fake_refresh_market_state)
+
+    market_specs = [{"type": "price_change", "symbol": "EURUSD"}]
+    observed_at_utc = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
+    snapshot = wait_events._collect_snapshot(
+        gateway=Gateway(),
+        baseline={},
+        history_state={},
+        market_state={"EURUSD": {"last_epoch": observed_at_utc.timestamp(), "ticks": []}},
+        started_at_utc=observed_at_utc,
+        observed_at_utc=observed_at_utc,
+        needs_orders=False,
+        needs_positions=False,
+        needs_history_deals=False,
+        needs_history_orders=False,
+        market_specs=market_specs,
+    )
+
+    assert snapshot["market_data"] == {
+        "EURUSD": {"last_epoch": observed_at_utc.timestamp(), "ticks": []}
+    }
+    assert captured["market_specs"] == market_specs

--- a/tests/core/test_wait_events_business_logic.py
+++ b/tests/core/test_wait_events_business_logic.py
@@ -6,7 +6,7 @@ from mtdata.core.data_requests import WaitEventRequest
 from mtdata.core import wait_events
 
 
-def test_compile_request_precomputes_waiter_requirements() -> None:
+def test_compile_request_precomputes_watcher_requirements() -> None:
     request = WaitEventRequest.model_validate(
         {
             "symbol": "EURUSD",


### PR DESCRIPTION
## Summary
- precompute wait-event watcher requirements once during request compilation instead of rescanning `watch_for` on every poll
- thread the derived flags and market-spec list through the baseline, history, and snapshot helpers
- add internal coverage for the new compile-time requirements and snapshot wiring

## Root cause
The wait-event polling loop repeatedly answered the same questions from `watch_for` on every wake-up: whether it needed open orders, positions, deal history, order history, or market-spec filtering. That repeated work lived in `_collect_snapshot()` and related helpers even though the answers only depend on the already-compiled watcher set.

## Implemented solution
- add one compile-time watcher-requirements pass that derives `needs_orders`, `needs_positions`, `needs_history_*`, and `market_specs`
- reuse those precomputed values in baseline building, account-history seeding, market-state bootstrap/refresh, and snapshot collection
- hoist the order/position union and history event sets to module-level constants
- add focused business-logic tests for the compiled requirements and market-spec snapshot wiring

## Trade-offs / limitations
This change is intentionally scoped to repeated watcher scans; it does not yet address the separate time-window bisect optimization report in the same module. Behavior stays the same, but the request compilation output now carries a few extra derived fields used only internally.

## Report
Resolves local report `code-reports/to-do/MED_wait-events-repeated-any-scans.md`.