### PR TITLE
Use bisect for wait-event time windows

### DIFF
--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -2071,11 +2071,13 @@ def _slice_prices_from_epoch(
     *,
     start_epoch: float,
     end_epoch: Optional[float] = None,
+    epochs: Optional[List[float]] = None,
 ) -> List[tuple[float, float]]:
-    start_idx = bisect_left(prices, (float(start_epoch), float("-inf")))
+    epoch_values = epochs if epochs is not None else [float(point[0]) for point in prices]
+    start_idx = bisect_left(epoch_values, float(start_epoch))
     if end_epoch is None:
         return prices[start_idx:]
-    end_idx = bisect_right(prices, (float(end_epoch), float("inf")))
+    end_idx = bisect_right(epoch_values, float(end_epoch))
     return prices[start_idx:end_idx]
 
 
@@ -2147,6 +2149,7 @@ def _duration_price_change_baseline_samples(
     current_start = latest_epoch - window_seconds
     baseline_start = current_start - baseline_seconds
     sample_count = max(1, int(math.floor(baseline_seconds / max(window_seconds, 1.0))))
+    price_epochs = [float(point[0]) for point in prices]
     samples: List[float] = []
     for sample_idx in range(sample_count):
         window_start = baseline_start + sample_idx * window_seconds
@@ -2157,6 +2160,7 @@ def _duration_price_change_baseline_samples(
             prices,
             start_epoch=window_start,
             end_epoch=window_end,
+            epochs=price_epochs,
         )
         if len(window_points) < 2:
             continue
@@ -2402,6 +2406,7 @@ def _window_metric_baseline_samples_for_prices(
     current_start = latest_epoch - window_seconds
     baseline_start = current_start - baseline_seconds
     sample_count = max(1, int(math.floor(baseline_seconds / max(window_seconds, 1.0))))
+    price_epochs = [float(point[0]) for point in prices]
     samples: List[float] = []
     for sample_idx in range(sample_count):
         window_start = baseline_start + sample_idx * window_seconds
@@ -2413,6 +2418,7 @@ def _window_metric_baseline_samples_for_prices(
                 prices,
                 start_epoch=window_start,
                 end_epoch=window_end,
+                epochs=price_epochs,
             )
         )
         if metric is not None:

--- a/src/mtdata/core/wait_events.py
+++ b/src/mtdata/core/wait_events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from bisect import bisect_left
+from bisect import bisect_left, bisect_right
 from datetime import datetime, timedelta, timezone
 import math
 import re
@@ -2066,6 +2066,34 @@ def _market_price_points(ticks: List[Dict[str, Any]], *, source: str) -> List[tu
     return points
 
 
+def _slice_prices_from_epoch(
+    prices: List[tuple[float, float]],
+    *,
+    start_epoch: float,
+    end_epoch: Optional[float] = None,
+) -> List[tuple[float, float]]:
+    start_idx = bisect_left(prices, (float(start_epoch), float("-inf")))
+    if end_epoch is None:
+        return prices[start_idx:]
+    end_idx = bisect_right(prices, (float(end_epoch), float("inf")))
+    return prices[start_idx:end_idx]
+
+
+def _slice_ticks_from_epoch(
+    ticks: List[Dict[str, Any]],
+    *,
+    start_epoch: float,
+    end_epoch: Optional[float] = None,
+    epochs: Optional[List[float]] = None,
+) -> List[Dict[str, Any]]:
+    epoch_values = epochs if epochs is not None else [float(tick["epoch"]) for tick in ticks]
+    start_idx = bisect_left(epoch_values, float(start_epoch))
+    if end_epoch is None:
+        return ticks[start_idx:]
+    end_idx = bisect_right(epoch_values, float(end_epoch))
+    return ticks[start_idx:end_idx]
+
+
 def _current_price_change(spec: Dict[str, Any], prices: List[tuple[float, float]]) -> Optional[float]:
     if not prices:
         return None
@@ -2077,7 +2105,7 @@ def _current_price_change(spec: Dict[str, Any], prices: List[tuple[float, float]
     window_seconds = float(spec["window"]["value"]) * 60.0
     end_epoch = prices[-1][0]
     start_epoch = end_epoch - window_seconds
-    window_points = [(epoch, price) for epoch, price in prices if epoch >= start_epoch]
+    window_points = _slice_prices_from_epoch(prices, start_epoch=start_epoch)
     if len(window_points) < 2:
         return None
     return _pct_change(window_points[0][1], window_points[-1][1])
@@ -2125,7 +2153,11 @@ def _duration_price_change_baseline_samples(
         window_end = min(window_start + window_seconds, current_start)
         if window_end <= window_start:
             continue
-        window_points = [(epoch, price) for epoch, price in prices if window_start <= epoch <= window_end]
+        window_points = _slice_prices_from_epoch(
+            prices,
+            start_epoch=window_start,
+            end_epoch=window_end,
+        )
         if len(window_points) < 2:
             continue
         change = _pct_change(window_points[0][1], window_points[-1][1])
@@ -2170,7 +2202,7 @@ def _current_volume_metric(
     window_seconds = float(spec["window"]["value"]) * 60.0
     end_epoch = ticks[-1]["epoch"]
     start_epoch = end_epoch - window_seconds
-    window_ticks_rows = [tick for tick in ticks if float(tick["epoch"]) >= start_epoch]
+    window_ticks_rows = _slice_ticks_from_epoch(ticks, start_epoch=start_epoch)
     if not window_ticks_rows:
         return None
     return _volume_metric_for_ticks(window_ticks_rows, source=source)
@@ -2202,15 +2234,19 @@ def _volume_baseline_samples(
     current_start = latest_epoch - window_seconds
     baseline_start = current_start - baseline_seconds
     sample_count = max(1, int(math.floor(baseline_seconds / max(window_seconds, 1.0))))
+    tick_epochs = [float(tick["epoch"]) for tick in ticks]
     samples: List[float] = []
     for sample_idx in range(sample_count):
         window_start = baseline_start + sample_idx * window_seconds
         window_end = min(window_start + window_seconds, current_start)
         if window_end <= window_start:
             continue
-        window_ticks_rows = [
-            tick for tick in ticks if window_start <= float(tick["epoch"]) <= window_end
-        ]
+        window_ticks_rows = _slice_ticks_from_epoch(
+            ticks,
+            start_epoch=window_start,
+            end_epoch=window_end,
+            epochs=tick_epochs,
+        )
         metric = _volume_metric_for_ticks(window_ticks_rows, source=source)
         if metric is None:
             continue
@@ -2323,6 +2359,7 @@ def _window_metric_baseline_samples(
     current_start = latest_epoch - window_seconds
     baseline_start = current_start - baseline_seconds
     sample_count = max(1, int(math.floor(baseline_seconds / max(window_seconds, 1.0))))
+    tick_epochs = [float(tick["epoch"]) for tick in ticks]
     samples: List[float] = []
     for sample_idx in range(sample_count):
         window_start = baseline_start + sample_idx * window_seconds
@@ -2330,11 +2367,12 @@ def _window_metric_baseline_samples(
         if window_end <= window_start:
             continue
         metric = metric_fn(
-            [
-                tick
-                for tick in ticks
-                if window_start <= float(tick["epoch"]) <= window_end
-            ]
+            _slice_ticks_from_epoch(
+                ticks,
+                start_epoch=window_start,
+                end_epoch=window_end,
+                epochs=tick_epochs,
+            )
         )
         if metric is not None:
             samples.append(metric)
@@ -2371,11 +2409,11 @@ def _window_metric_baseline_samples_for_prices(
         if window_end <= window_start:
             continue
         metric = metric_fn(
-            [
-                (epoch, price)
-                for epoch, price in prices
-                if window_start <= epoch <= window_end
-            ]
+            _slice_prices_from_epoch(
+                prices,
+                start_epoch=window_start,
+                end_epoch=window_end,
+            )
         )
         if metric is not None:
             samples.append(metric)
@@ -2393,7 +2431,7 @@ def _window_ticks(ticks: List[Dict[str, Any]], window: Dict[str, Any]) -> List[D
     window_seconds = float(window["value"]) * 60.0
     end_epoch = float(ticks[-1]["epoch"])
     start_epoch = end_epoch - window_seconds
-    return [tick for tick in ticks if float(tick["epoch"]) >= start_epoch]
+    return _slice_ticks_from_epoch(ticks, start_epoch=start_epoch)
 
 
 def _window_prices(prices: List[tuple[float, float]], window: Dict[str, Any]) -> List[tuple[float, float]]:
@@ -2407,7 +2445,7 @@ def _window_prices(prices: List[tuple[float, float]], window: Dict[str, Any]) ->
     window_seconds = float(window["value"]) * 60.0
     end_epoch = float(prices[-1][0])
     start_epoch = end_epoch - window_seconds
-    return [(epoch, price) for epoch, price in prices if epoch >= start_epoch]
+    return _slice_prices_from_epoch(prices, start_epoch=start_epoch)
 
 
 def _spread_values_for_ticks(ticks: List[Dict[str, Any]]) -> List[float]:

--- a/tests/core/test_wait_event_window_business_logic.py
+++ b/tests/core/test_wait_event_window_business_logic.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from mtdata.core import wait_events
+
+
+def test_window_ticks_uses_time_window_cutoff() -> None:
+    ticks = [
+        {"epoch": 10.0},
+        {"epoch": 40.0},
+        {"epoch": 80.0},
+        {"epoch": 100.0},
+    ]
+
+    out = wait_events._window_ticks(ticks, {"kind": "minutes", "value": 0.5})
+
+    assert [tick["epoch"] for tick in out] == [80.0, 100.0]
+
+
+def test_window_prices_uses_time_window_cutoff() -> None:
+    prices = [
+        (10.0, 100.0),
+        (40.0, 101.0),
+        (80.0, 102.0),
+        (100.0, 103.0),
+    ]
+
+    out = wait_events._window_prices(prices, {"kind": "minutes", "value": 0.5})
+
+    assert out == [(80.0, 102.0), (100.0, 103.0)]
+
+
+def test_duration_price_change_baseline_samples_preserve_time_window_boundaries() -> None:
+    spec = {
+        "window": {"kind": "minutes", "value": 1.0},
+        "baseline_window": {"kind": "minutes", "value": 2.0},
+    }
+    prices = [
+        (0.0, 100.0),
+        (30.0, 101.0),
+        (60.0, 102.0),
+        (90.0, 103.0),
+        (120.0, 104.0),
+        (150.0, 105.0),
+        (180.0, 106.0),
+    ]
+
+    out = wait_events._duration_price_change_baseline_samples(spec, prices)
+
+    assert out[0] == pytest.approx(2.0)
+    assert out[1] == pytest.approx(((104.0 - 102.0) / 102.0) * 100.0)

--- a/tests/core/test_wait_event_window_business_logic.py
+++ b/tests/core/test_wait_event_window_business_logic.py
@@ -31,6 +31,24 @@ def test_window_prices_uses_time_window_cutoff() -> None:
     assert out == [(80.0, 102.0), (100.0, 103.0)]
 
 
+def test_slice_prices_from_epoch_accepts_explicit_epochs_for_duplicate_timestamps() -> None:
+    prices = [
+        (10.0, 101.0),
+        (10.0, 99.0),
+        (40.0, 102.0),
+    ]
+    epochs = [10.0, 10.0, 40.0]
+
+    out = wait_events._slice_prices_from_epoch(
+        prices,
+        start_epoch=10.0,
+        end_epoch=10.0,
+        epochs=epochs,
+    )
+
+    assert out == prices[:2]
+
+
 def test_duration_price_change_baseline_samples_preserve_time_window_boundaries() -> None:
     spec = {
         "window": {"kind": "minutes", "value": 1.0},


### PR DESCRIPTION
## Summary
- replace repeated time-window scans in `wait_events.py` with bisect-backed slicing helpers for prices and ticks
- reuse a single epoch list inside the repeated tick-window baseline loops
- add focused helper-level coverage for the new time-window slicing behavior

## Root cause
Several wait-event helpers rebuilt post-start windows by scanning the entire sorted price or tick history on every call. In the baseline-sample loops that meant repeating those linear scans many times per poll iteration even though the input data was already ordered by epoch.

## Implemented solution
- add `_slice_prices_from_epoch()` and `_slice_ticks_from_epoch()` to binary-search the relevant start/end indices and slice the original sorted lists
- update the time-based price-change, volume, spread/range baseline, and window helpers to use those bisect-backed slices
- reuse a precomputed tick-epoch list inside the repeated baseline loops so the tick functions avoid rebuilding epoch lookups for every sample window
- add focused helper tests for the time-window cutoffs and baseline window boundaries

## Trade-offs / limitations
This change is scoped to the time-window filtering helpers listed in the report. It does not combine with the separate watcher-precompute refactor from the other wait-event performance report, so the two optimizations remain independently reviewable.

## Report
Resolves local report `code-reports/to-do/MED_wait-events-missing-bisect-optimization.md`.