### PR TITLE
Correct conformal finite-sample quantiles

### DIFF
--- a/src/mtdata/forecast/use_cases.py
+++ b/src/mtdata/forecast/use_cases.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import difflib
 import importlib
 import logging
+import math
 import os
 import pkgutil
 import time
@@ -81,6 +82,21 @@ def _discover_sktime_forecasters() -> Dict[str, Tuple[str, str]]:
 
 def _normalize_forecaster_name(name: str) -> str:
     return "".join(ch for ch in str(name).lower() if ch.isalnum())
+
+
+def _finite_sample_conformal_quantile(values: List[float], alpha: float) -> float:
+    if not values:
+        return float("nan")
+
+    import numpy as _np
+
+    arr = _np.asarray(values, dtype=float)
+    if _np.isnan(arr).any():
+        return float("nan")
+
+    n = int(arr.size)
+    rank = max(1, min(n, math.ceil((n + 1) * (1.0 - float(alpha)))))
+    return float(_np.partition(arr, rank - 1)[rank - 1])
 
 
 def _resolve_sktime_forecaster(method: str) -> Optional[Tuple[str, str]]:
@@ -368,9 +384,8 @@ def run_forecast_conformal_intervals(
 
         import numpy as _np
 
-        q = 1.0 - float(request.ci_alpha)
         qerrs = [
-            float(_np.quantile(_np.array(err, dtype=float), q)) if err else float("nan")
+            _finite_sample_conformal_quantile(err, float(request.ci_alpha))
             for err in errs
         ]
 

--- a/tests/forecast/test_core_forecast_business_logic.py
+++ b/tests/forecast/test_core_forecast_business_logic.py
@@ -622,6 +622,35 @@ def test_run_forecast_conformal_intervals_routes_method_params_consistently():
     assert captured["forecast"]["params"] == {"seasonality": 24}
 
 
+def test_run_forecast_conformal_intervals_uses_finite_sample_quantile():
+    result = forecast_use_cases.run_forecast_conformal_intervals(
+        ForecastConformalIntervalsRequest(
+            symbol="EURUSD",
+            method="theta",
+            horizon=1,
+            steps=3,
+            spacing=1,
+            ci_alpha=0.25,
+        ),
+        backtest_impl=lambda **kwargs: {
+            "results": {
+                "theta": {
+                    "details": [
+                        {"forecast": [10.0], "actual": [9.0]},
+                        {"forecast": [10.0], "actual": [8.0]},
+                        {"forecast": [10.0], "actual": [7.0]},
+                    ]
+                }
+            }
+        },
+        forecast_impl=lambda **kwargs: {"forecast_price": [100.0]},
+    )
+
+    assert result["conformal"]["per_step_q"] == [3.0]
+    assert result["lower_price"] == [97.0]
+    assert result["upper_price"] == [103.0]
+
+
 def test_run_forecast_conformal_intervals_raises_typed_error_for_nested_error_payload():
     with pytest.raises(ForecastError, match="backtest failed"):
         forecast_use_cases.run_forecast_conformal_intervals(


### PR DESCRIPTION
## Summary
- apply the finite-sample conformal quantile correction when building per-step calibration residual cutoffs
- keep the existing held-out rolling residual collection path intact
- add a regression covering the previously under-calibrated small-sample case

## Root cause
`run_forecast_conformal_intervals()` already calibrated on genuine held-out rolling backtest residuals, but it fed those residuals into the plain empirical quantile. For small calibration sets that interpolated between order statistics instead of selecting the corrected conformal cutoff `ceil((n+1)*(1-alpha))`, which made the resulting intervals narrower than the finite-sample conformal guarantee requires.

## Implemented solution
- add a small helper that selects the corrected conformal order statistic for each forecast step's residual bucket
- preserve the existing NaN handling by returning `nan` when a calibration bucket contains NaNs
- add a focused regression that proves a three-sample 75% interval now uses the maximum residual rather than an interpolated midpoint

## Trade-offs / limitations
This change tightens the calibration cutoff only in the conformal-interval use case. It does not change how individual forecasting methods compute any native confidence intervals.

## Report
Resolves local report `code-reports/to-do/MED_conformal-intervals-calibration.md`.