### PR TITLE
Expose resolved barrier bootstrap metrics

### DIFF
--- a/src/mtdata/forecast/barrier_stats.py
+++ b/src/mtdata/forecast/barrier_stats.py
@@ -565,10 +565,9 @@ def bootstrap_metric_uncertainty(
         ev = prob_tp_first * net_reward - prob_sl_first * net_risk
         kelly = prob_tp_first - (prob_sl_first / net_rr) if net_rr > 0 else 0.0
 
-        active = prob_tp_first + prob_sl_first
-        if active > 0:
-            prob_win_c = prob_tp_first / active
-            prob_loss_c = prob_sl_first / active
+        if prob_resolve > 0:
+            prob_win_c = prob_tp_first / prob_resolve
+            prob_loss_c = prob_sl_first / prob_resolve
             ev_cond = prob_win_c * net_reward - prob_loss_c * net_risk
             kelly_cond = prob_win_c - (prob_loss_c / net_rr) if net_rr > 0 else 0.0
         else:

--- a/src/mtdata/forecast/barrier_stats.py
+++ b/src/mtdata/forecast/barrier_stats.py
@@ -505,8 +505,8 @@ def bootstrap_metric_uncertainty(
     
     if metrics is None:
         metrics = [
-            'prob_win', 'prob_loss', 'prob_tp_first', 'prob_sl_first',
-            'ev', 'edge', 'kelly', 'prob_no_hit'
+            'prob_win', 'prob_loss', 'prob_tie', 'prob_tp_first', 'prob_sl_first',
+            'ev', 'ev_cond', 'edge', 'kelly', 'kelly_cond', 'prob_no_hit', 'prob_resolve'
         ]
     
     rng = np.random.RandomState(seed)
@@ -548,6 +548,7 @@ def bootstrap_metric_uncertainty(
         prob_tp_first = (n_wins + 0.5 * n_ties) / n_sims
         prob_sl_first = (n_losses + 0.5 * n_ties) / n_sims
         prob_no_hit = 1.0 - (any_tp | any_sl).sum() / n_sims
+        prob_resolve = 1.0 - prob_no_hit
         
         edge = prob_win - prob_loss
 
@@ -562,8 +563,17 @@ def bootstrap_metric_uncertainty(
         net_risk = gross_risk + max(0.0, float(cost_per_trade or 0.0))
         net_rr = net_reward / net_risk if net_risk > 0 else 0.0
         ev = prob_tp_first * net_reward - prob_sl_first * net_risk
-
         kelly = prob_tp_first - (prob_sl_first / net_rr) if net_rr > 0 else 0.0
+
+        active = prob_tp_first + prob_sl_first
+        if active > 0:
+            prob_win_c = prob_tp_first / active
+            prob_loss_c = prob_sl_first / active
+            ev_cond = prob_win_c * net_reward - prob_loss_c * net_risk
+            kelly_cond = prob_win_c - (prob_loss_c / net_rr) if net_rr > 0 else 0.0
+        else:
+            ev_cond = 0.0
+            kelly_cond = 0.0
         
         for metric in metrics:
             val = locals().get(metric)

--- a/tests/forecast/test_barrier_stats.py
+++ b/tests/forecast/test_barrier_stats.py
@@ -301,6 +301,43 @@ class TestBarrierStats(unittest.TestCase):
 
         self.assertAlmostEqual(result['ev']['mean'], 0.15, places=12)
         self.assertAlmostEqual(result['kelly']['mean'], 0.375, places=12)
+
+    def test_bootstrap_metric_uncertainty_reports_conditional_metrics_with_no_hit_paths(self):
+        """Bootstrap uncertainty should expose resolved-only EV/Kelly when paths stay open."""
+        from unittest.mock import patch
+
+        class FakeRandomState:
+            def __init__(self, seed=None):
+                self.seed = seed
+
+            def choice(self, n_sims, size, replace=True):
+                return np.array([0, 1, 2, 3])
+
+        paths = np.array([
+            [105.0, 111.0],
+            [105.0, 111.0],
+            [95.0, 89.0],
+            [100.0, 100.0],
+        ])
+
+        with patch('mtdata.forecast.barrier_stats.np.random.RandomState', FakeRandomState):
+            result = bootstrap_metric_uncertainty(
+                paths=paths,
+                tp_trigger=110.0,
+                sl_trigger=90.0,
+                direction='long',
+                entry_price=100.0,
+                n_bootstrap=2,
+                metrics=['ev', 'ev_cond', 'kelly', 'kelly_cond', 'prob_no_hit', 'prob_resolve'],
+                seed=42,
+            )
+
+        self.assertAlmostEqual(result['prob_no_hit']['mean'], 0.25, places=12)
+        self.assertAlmostEqual(result['prob_resolve']['mean'], 0.75, places=12)
+        self.assertAlmostEqual(result['ev']['mean'], 2.5, places=12)
+        self.assertAlmostEqual(result['ev_cond']['mean'], 10.0 / 3.0, places=12)
+        self.assertAlmostEqual(result['kelly']['mean'], 0.25, places=12)
+        self.assertAlmostEqual(result['kelly_cond']['mean'], 1.0 / 3.0, places=12)
     
     def test_statistical_power_analysis_high_power(self):
         """Test power analysis with high power scenario."""


### PR DESCRIPTION
## Summary
- extend barrier bootstrap uncertainty outputs with `prob_tie`, `prob_resolve`, `ev_cond`, and `kelly_cond`
- keep the existing unconditional EV/Kelly summaries intact for compatibility with the base optimizer metrics
- add a regression that exercises the high-`prob_no_hit` case and proves the resolved-only summaries differ from the unconditional ones

## Root cause
The optional bootstrap uncertainty helper only emitted unconditional EV/Kelly-style summaries even though the optimizer already distinguishes unresolved paths via `prob_no_hit` and exposes resolved-only `ev_cond` / `kelly_cond` metrics on the main candidate rows. When many simulated paths stayed open through the horizon, the robustness block had no way to surface the resolved-only view, so the statistical summary was incomplete exactly in the scenario the report called out.

## Implemented solution
- add `prob_tie` and `prob_resolve` to the bootstrap metric set
- compute `ev_cond` and `kelly_cond` from the resolved subset while preserving the existing unconditional `ev` and `kelly`
- add focused regression coverage for a bootstrap sample with a non-trivial no-hit share

## Trade-offs / limitations
This change is additive: existing `ev` and `kelly` summaries are preserved so current consumers do not break, and the no-hit-aware conditional variants are now available alongside them. It does not redefine the base optimizer's existing unconditional metrics.

## Report
Resolves local report `code-reports/to-do/MED_monte-carlo-barrier-probability-bugs.md`.