### PR TITLE
Vectorize Monte Carlo price reconstruction

### DIFF
--- a/src/mtdata/forecast/monte_carlo.py
+++ b/src/mtdata/forecast/monte_carlo.py
@@ -290,11 +290,7 @@ def simulate_hmm_mc(
 
     # Build price paths from last observed price
     last_price = float(prices[-1])
-    price_paths = np.zeros_like(ret_paths, dtype=float)
-    cur = np.full(int(n_sims), last_price, dtype=float)
-    for t in range(int(horizon)):
-        cur = cur * np.exp(ret_paths[:, t])
-        price_paths[:, t] = cur
+    price_paths = last_price * np.exp(np.cumsum(ret_paths, axis=1))
 
     return {
         'price_paths': price_paths,
@@ -341,11 +337,7 @@ def simulate_gbm_mc(
         ret_paths = mu + sigma * z
     else:
         ret_paths = rng.normal(loc=mu, scale=sigma, size=(sims_i, horizon_i))
-    price_paths = np.zeros_like(ret_paths)
-    cur = np.full(sims_i, last_price, dtype=float)
-    for t in range(horizon_i):
-        cur = cur * np.exp(ret_paths[:, t])
-        price_paths[:, t] = cur
+    price_paths = last_price * np.exp(np.cumsum(ret_paths, axis=1))
     return {
         'price_paths': price_paths,
         'return_paths': ret_paths,

--- a/tests/forecast/test_monte_carlo_pure.py
+++ b/tests/forecast/test_monte_carlo_pure.py
@@ -207,6 +207,12 @@ class TestSimulateGbmMc:
         result = simulate_gbm_mc(self._prices(), horizon=20, n_sims=30, seed=7)
         assert np.all(result["price_paths"] > 0)
 
+    def test_price_paths_follow_cumulative_returns(self):
+        prices = self._prices()
+        result = simulate_gbm_mc(prices, horizon=6, n_sims=8, seed=3, antithetic=False)
+        expected = float(prices[-1]) * np.exp(np.cumsum(result["return_paths"], axis=1))
+        np.testing.assert_allclose(result["price_paths"], expected)
+
     def test_sigma_uses_sample_standard_deviation(self):
         prices = np.array([100.0, 101.0, 103.0, 102.0, 104.0], dtype=float)
         result = simulate_gbm_mc(prices, horizon=2, n_sims=4, seed=1)
@@ -237,6 +243,12 @@ class TestSimulateHmmMc:
         assert "trans" in result
         assert result["model_type"] == "gaussian_hmm_baum_welch"
         assert result["price_paths"].shape == (30, 10)
+
+    def test_price_paths_follow_cumulative_returns(self):
+        prices = self._prices()
+        result = simulate_hmm_mc(prices, horizon=6, n_sims=12, seed=4)
+        expected = float(prices[-1]) * np.exp(np.cumsum(result["return_paths"], axis=1))
+        np.testing.assert_allclose(result["price_paths"], expected)
 
     def test_too_few(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- replace the remaining loop-based price reconstruction in `simulate_gbm_mc()` and `simulate_hmm_mc()` with the vectorized cumulative-return formula already used by the other simulators
- keep the return-path generation unchanged
- add invariant tests that lock `price_paths == last_price * exp(cumsum(return_paths))`

## Root cause
`monte_carlo.py` already used the vectorized cumulative-return reconstruction in several simulators, but GBM and HMM still rebuilt prices one horizon step at a time in Python loops. That created avoidable overhead in hot simulation paths while producing the same numeric result.

## Implemented solution
- switch both affected simulators to `last_price * np.exp(np.cumsum(ret_paths, axis=1))`
- add focused regression tests for GBM and HMM that assert the reconstructed price paths still match the cumulative return paths exactly

## Trade-offs / limitations
This change is intentionally behavior-preserving and only targets the reconstruction step. It does not alter calibration, random sampling, or any barrier-analysis logic that consumes the simulated paths.

## Report
Resolves local report `code-reports/to-do/MED_monte-carlo-unvectorized-price-reconstruction.md`.