### PR TITLE
Share ensemble dispatch error helpers

### DIFF
--- a/src/mtdata/forecast/ensemble_dispatch.py
+++ b/src/mtdata/forecast/ensemble_dispatch.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
-import numpy as np
-import pandas as pd
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
 
 FAILURE_DETAIL_LIMIT = 12
 

--- a/src/mtdata/forecast/ensemble_dispatch.py
+++ b/src/mtdata/forecast/ensemble_dispatch.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+FAILURE_DETAIL_LIMIT = 12
+
+
+def clear_dispatch_error(dispatch_method: Any) -> None:
+    try:
+        setattr(dispatch_method, "_last_error", None)
+    except Exception:
+        pass
+
+
+def build_dispatch_error(method_name: str, exc: BaseException) -> Dict[str, Any]:
+    return {
+        "method": str(method_name),
+        "error": str(exc),
+        "error_type": type(exc).__name__,
+    }
+
+
+def consume_dispatch_error(dispatch_method: Any, *, method_name: str) -> Optional[Dict[str, Any]]:
+    try:
+        error = getattr(dispatch_method, "_last_error", None)
+    except Exception:
+        return None
+    try:
+        setattr(dispatch_method, "_last_error", None)
+    except Exception:
+        pass
+    if not isinstance(error, dict):
+        return None
+    payload = dict(error)
+    payload.setdefault("method", str(method_name))
+    return payload
+
+
+def dispatch_callback_with_error(
+    dispatch_method: Callable[[str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]], Optional[np.ndarray]],
+    method_name: str,
+    series: pd.Series,
+    horizon: int,
+    seasonality: Optional[int],
+    params: Optional[Dict[str, Any]],
+) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
+    method_l = str(method_name).lower().strip()
+    try:
+        forecast = dispatch_method(method_l, series, horizon, seasonality, params)
+    except Exception as ex:
+        return None, build_dispatch_error(method_l, ex)
+    if forecast is None:
+        return None, consume_dispatch_error(dispatch_method, method_name=method_l)
+    return forecast, None
+
+
+def append_failure(
+    failures: Optional[List[Dict[str, Any]]],
+    *,
+    stage: str,
+    method_name: str,
+    error_detail: Optional[Dict[str, Any]] = None,
+    anchor_index: Optional[int] = None,
+) -> None:
+    if failures is None or len(failures) >= FAILURE_DETAIL_LIMIT:
+        return
+    payload: Dict[str, Any] = {
+        "stage": str(stage),
+        "method": str(method_name),
+    }
+    if anchor_index is not None:
+        payload["anchor_index"] = int(anchor_index)
+    if isinstance(error_detail, dict):
+        for key, value in error_detail.items():
+            if value is not None:
+                payload[str(key)] = value
+    failures.append(payload)

--- a/src/mtdata/forecast/forecast_engine.py
+++ b/src/mtdata/forecast/forecast_engine.py
@@ -30,6 +30,11 @@ from .common import (
     fetch_history as _fetch_history,
     next_times_from_last,
 )
+from .ensemble_dispatch import (
+    append_failure as _append_ensemble_failure,
+    build_dispatch_error as _build_ensemble_dispatch_error,
+    dispatch_callback_with_error as _dispatch_ensemble_callback_with_error,
+)
 from .forecast_validation import format_invalid_method_error
 from .interface import ForecastCallContext
 from .registry import ForecastRegistry
@@ -78,73 +83,6 @@ _ENSEMBLE_BASE_METHODS = (
 
 logger = logging.getLogger(__name__)
 _normalize_weights = _normalize_weights_impl
-
-
-def _build_ensemble_dispatch_error(method_name: str, exc: BaseException) -> Dict[str, Any]:
-    return {
-        "method": str(method_name),
-        "error": str(exc),
-        "error_type": type(exc).__name__,
-    }
-
-
-def _consume_dispatch_callback_error(
-    dispatch_method: Any,
-    *,
-    method_name: str,
-) -> Optional[Dict[str, Any]]:
-    try:
-        error = getattr(dispatch_method, "_last_error", None)
-    except Exception:
-        return None
-    try:
-        setattr(dispatch_method, "_last_error", None)
-    except Exception:
-        pass
-    if not isinstance(error, dict):
-        return None
-    payload = dict(error)
-    payload.setdefault("method", str(method_name))
-    return payload
-
-
-def _dispatch_ensemble_callback_with_error(
-    dispatch_method: Callable[[str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]], Optional[np.ndarray]],
-    method_name: str,
-    series: pd.Series,
-    horizon: int,
-    seasonality: Optional[int],
-    params: Optional[Dict[str, Any]],
-) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
-    method_l = str(method_name).lower().strip()
-    try:
-        forecast = dispatch_method(method_l, series, horizon, seasonality, params)
-    except Exception as ex:
-        return None, _build_ensemble_dispatch_error(method_l, ex)
-    if forecast is None:
-        return None, _consume_dispatch_callback_error(dispatch_method, method_name=method_l)
-    return forecast, None
-
-
-def _append_ensemble_failure(
-    failures: Optional[List[Dict[str, Any]]],
-    *,
-    method_name: str,
-    anchor_index: int,
-    error_detail: Optional[Dict[str, Any]],
-) -> None:
-    if failures is None or len(failures) >= 12:
-        return
-    payload: Dict[str, Any] = {
-        "stage": "cv",
-        "method": str(method_name),
-        "anchor_index": int(anchor_index),
-    }
-    if isinstance(error_detail, dict):
-        for key, value in error_detail.items():
-            if value is not None:
-                payload[str(key)] = value
-    failures.append(payload)
 
 
 def _ensemble_dispatch_method_impl(
@@ -253,6 +191,7 @@ def _prepare_ensemble_cv(
             if fc is None:
                 _append_ensemble_failure(
                     failure_sink,
+                    stage="cv",
                     method_name=m,
                     anchor_index=idx,
                     error_detail=error_detail
@@ -265,6 +204,7 @@ def _prepare_ensemble_cv(
             except Exception as ex:
                 _append_ensemble_failure(
                     failure_sink,
+                    stage="cv",
                     method_name=m,
                     anchor_index=idx,
                     error_detail={"error": str(ex), "error_type": type(ex).__name__},
@@ -274,6 +214,7 @@ def _prepare_ensemble_cv(
             if fc_arr.size < horizon_i or not np.all(np.isfinite(fc_arr[:horizon_i])):
                 _append_ensemble_failure(
                     failure_sink,
+                    stage="cv",
                     method_name=m,
                     anchor_index=idx,
                     error_detail={"error": "Forecast output was too short or non-finite", "error_type": "invalid_forecast"},

--- a/src/mtdata/forecast/methods/ensemble.py
+++ b/src/mtdata/forecast/methods/ensemble.py
@@ -7,81 +7,14 @@ import numpy as np
 import pandas as pd
 
 from ..common import _normalize_weights as _normalize_weights_default
+from ..ensemble_dispatch import (
+    append_failure as _append_failure,
+    build_dispatch_error as _build_dispatch_error,
+    clear_dispatch_error as _clear_dispatch_error,
+    dispatch_callback_with_error as _dispatch_callback_with_error,
+)
 from ..interface import ForecastCallContext, ForecastMethod, ForecastResult
 from ..registry import ForecastRegistry
-
-_FAILURE_DETAIL_LIMIT = 12
-
-
-def _clear_dispatch_error(dispatch_method: Any) -> None:
-    try:
-        setattr(dispatch_method, "_last_error", None)
-    except Exception:
-        pass
-
-def _build_dispatch_error(method_name: str, exc: BaseException) -> Dict[str, Any]:
-    return {
-        "method": str(method_name),
-        "error": str(exc),
-        "error_type": type(exc).__name__,
-    }
-
-
-def _consume_dispatch_error(dispatch_method: Any, *, method_name: str) -> Optional[Dict[str, Any]]:
-    try:
-        error = getattr(dispatch_method, "_last_error", None)
-    except Exception:
-        return None
-    try:
-        setattr(dispatch_method, "_last_error", None)
-    except Exception:
-        pass
-    if not isinstance(error, dict):
-        return None
-    payload = dict(error)
-    payload.setdefault("method", str(method_name))
-    return payload
-
-
-def _dispatch_callback_with_error(
-    dispatch_method: Callable[[str, pd.Series, int, Optional[int], Optional[Dict[str, Any]]], Optional[np.ndarray]],
-    method_name: str,
-    series: pd.Series,
-    horizon: int,
-    seasonality: Optional[int],
-    params: Optional[Dict[str, Any]],
-) -> Tuple[Optional[np.ndarray], Optional[Dict[str, Any]]]:
-    method_l = str(method_name).lower().strip()
-    try:
-        forecast = dispatch_method(method_l, series, horizon, seasonality, params)
-    except Exception as ex:
-        return None, _build_dispatch_error(method_l, ex)
-    if forecast is None:
-        return None, _consume_dispatch_error(dispatch_method, method_name=method_l)
-    return forecast, None
-
-
-def _append_failure(
-    failures: Optional[List[Dict[str, Any]]],
-    *,
-    stage: str,
-    method_name: str,
-    error_detail: Optional[Dict[str, Any]] = None,
-    anchor_index: Optional[int] = None,
-) -> None:
-    if failures is None or len(failures) >= _FAILURE_DETAIL_LIMIT:
-        return
-    payload: Dict[str, Any] = {
-        "stage": str(stage),
-        "method": str(method_name),
-    }
-    if anchor_index is not None:
-        payload["anchor_index"] = int(anchor_index)
-    if isinstance(error_detail, dict):
-        for key, value in error_detail.items():
-            if value is not None:
-                payload[str(key)] = value
-    failures.append(payload)
 
 
 def _stabilized_bma_weights(rmse: np.ndarray) -> Optional[np.ndarray]:

--- a/src/mtdata/forecast/methods/ensemble.py
+++ b/src/mtdata/forecast/methods/ensemble.py
@@ -10,7 +10,6 @@ from ..common import _normalize_weights as _normalize_weights_default
 from ..ensemble_dispatch import (
     append_failure as _append_failure,
     build_dispatch_error as _build_dispatch_error,
-    clear_dispatch_error as _clear_dispatch_error,
     dispatch_callback_with_error as _dispatch_callback_with_error,
 )
 from ..interface import ForecastCallContext, ForecastMethod, ForecastResult


### PR DESCRIPTION
## Summary
- extract the duplicated ensemble dispatch-error plumbing into a shared `forecast/ensemble_dispatch.py` helper module
- reuse that shared helper from both `forecast_engine.py` and `methods/ensemble.py`
- keep the engine's implicit CV-stage failure metadata intact while removing the duplicate implementations

## Root cause
Both the forecast engine and the ensemble method had grown their own near-identical helpers for building dispatch errors, consuming callback-attached `_last_error` payloads, wrapping dispatch callbacks, and appending failure metadata. The code paths were still aligned, but they were close enough to drift independently on the next change.

## Implemented solution
- add `forecast/ensemble_dispatch.py` with the shared dispatch-error and failure-append helpers
- replace the duplicate helper bodies in `forecast_engine.py` and `methods/ensemble.py` with imports from the shared module
- preserve the engine's `stage="cv"` failure records at the call sites so the output shape stays unchanged

## Trade-offs / limitations
This is a maintenance refactor only; it does not change how ensemble components are selected, dispatched, or reported beyond centralizing the shared helper logic. The broader trading-order duplication report remains separate because it is a larger scaffold extraction.

## Report
Resolves local report `code-reports/to-do/MED_duplicate-ensemble-dispatch-error-handling.md`.