### PR TITLE
Share trading done retcode helpers

### DIFF
--- a/src/mtdata/core/trading_execution.py
+++ b/src/mtdata/core/trading_execution.py
@@ -74,31 +74,11 @@ def _unexpected_operation_error(
     return payload
 
 
-def _trade_done_codes(mt5: Any) -> set[int]:
-    return {
-        int(getattr(mt5, "TRADE_RETCODE_DONE", 10009)),
-        int(getattr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010)),
-    }
-
-
-def _retcode_is_done(
-    mt5: Any,
-    retcode: Any,
-    done_codes: Optional[set[int]] = None,
-) -> bool:
-    try:
-        if done_codes is None:
-            done_codes = _trade_done_codes(mt5)
-        return int(retcode) in done_codes
-    except Exception:
-        return False
-
-
 def _count_done_results(mt5: Any, results: List[Dict[str, Any]]) -> int:
     success_count = 0
-    done_codes = _trade_done_codes(mt5)
+    done_codes = trading_validation._trade_done_codes(mt5)
     for item in results:
-        if _retcode_is_done(mt5, item.get("retcode"), done_codes):
+        if trading_validation._retcode_is_done(mt5, item.get("retcode"), done_codes):
             success_count += 1
     return success_count
 
@@ -749,7 +729,7 @@ def _close_positions(
                                 break
                             if recovered:
                                 retcode_val = getattr(result, "retcode", None)
-                                if _retcode_is_done(mt5, retcode_val):
+                                if trading_validation._retcode_is_done(mt5, retcode_val):
                                     break
                                 time.sleep(0.15)
                                 continue
@@ -772,11 +752,11 @@ def _close_positions(
                             "comment": getattr(result, "comment", None),
                         }
                     )
-                    if _retcode_is_done(mt5, retcode_val):
+                    if trading_validation._retcode_is_done(mt5, retcode_val):
                         break
                     time.sleep(0.15)
 
-                close_ok = _retcode_is_done(mt5, getattr(result, "retcode", None)) if result is not None else False
+                close_ok = trading_validation._retcode_is_done(mt5, getattr(result, "retcode", None)) if result is not None else False
 
                 if not close_ok:
                     last_error = trading_validation._safe_last_error(mt5)

--- a/src/mtdata/core/trading_orders.py
+++ b/src/mtdata/core/trading_orders.py
@@ -74,20 +74,6 @@ def _send_order_with_comment_fallback(
     request: Dict[str, Any],
 ) -> tuple[Any, Optional[Dict[str, Any]], Any]:
     return trading_comments._send_order_with_comment_fallback(mt5, request)
-
-
-def _trade_done_codes(mt5: Any) -> set[int]:
-    return {
-        trading_validation._safe_int_attr(mt5, "TRADE_RETCODE_DONE", 10009),
-        trading_validation._safe_int_attr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010),
-    }
-
-
-def _retcode_is_done(mt5: Any, retcode: Any) -> bool:
-    try:
-        return int(retcode) in _trade_done_codes(mt5)
-    except Exception:
-        return False
 def _send_order_with_fill_mode_retry(
     mt5: Any,
     request: Dict[str, Any],
@@ -122,7 +108,7 @@ def _send_order_with_fill_mode_retry(
             else attempt_request
         )
         try:
-            if result is not None and _retcode_is_done(mt5, getattr(result, "retcode", -1)):
+            if result is not None and trading_validation._retcode_is_done(mt5, getattr(result, "retcode", -1)):
                 return result, comment_fallback, last_error, attempts, last_request
         except Exception:
             pass
@@ -285,7 +271,7 @@ def _place_market_order(
                     "comment_fallback": comment_fallback,
                     "fill_mode_attempts": fill_mode_attempts,
                 }
-            if not _retcode_is_done(mt5, getattr(result, "retcode", None)):
+            if not trading_validation._retcode_is_done(mt5, getattr(result, "retcode", None)):
                 error_message = "Failed to send order"
                 invalid_comment = (
                     comment_fallback.get("invalid_comment_error")
@@ -783,7 +769,7 @@ def _place_pending_order(
                     "fill_mode_attempts": fill_mode_attempts,
                 }
 
-            if not _retcode_is_done(mt5, getattr(result, "retcode", None)):
+            if not trading_validation._retcode_is_done(mt5, getattr(result, "retcode", None)):
                 error_message = "Failed to send pending order"
                 invalid_comment = (
                     comment_fallback.get("invalid_comment_error")

--- a/src/mtdata/core/trading_orders.py
+++ b/src/mtdata/core/trading_orders.py
@@ -74,6 +74,8 @@ def _send_order_with_comment_fallback(
     request: Dict[str, Any],
 ) -> tuple[Any, Optional[Dict[str, Any]], Any]:
     return trading_comments._send_order_with_comment_fallback(mt5, request)
+
+
 def _send_order_with_fill_mode_retry(
     mt5: Any,
     request: Dict[str, Any],

--- a/src/mtdata/core/trading_validation.py
+++ b/src/mtdata/core/trading_validation.py
@@ -186,6 +186,26 @@ def _safe_int_attr(obj: Any, name: str, default: int) -> int:
     return int(numeric)
 
 
+def _trade_done_codes(mt5: Any) -> set[int]:
+    return {
+        _safe_int_attr(mt5, "TRADE_RETCODE_DONE", 10009),
+        _safe_int_attr(mt5, "TRADE_RETCODE_DONE_PARTIAL", 10010),
+    }
+
+
+def _retcode_is_done(
+    mt5: Any,
+    retcode: Any,
+    done_codes: Optional[set[int]] = None,
+) -> bool:
+    try:
+        if done_codes is None:
+            done_codes = _trade_done_codes(mt5)
+        return int(retcode) in done_codes
+    except Exception:
+        return False
+
+
 def _candidate_fill_modes(mt5: Any) -> list[int]:
     """Return deduplicated fill-mode candidates with stable MT5-compatible fallbacks."""
     fill_modes: list[int] = []

--- a/tests/trading/test_trading_business_logic_additional.py
+++ b/tests/trading/test_trading_business_logic_additional.py
@@ -9,6 +9,8 @@ from mtdata.core.trading_time import _server_time_naive_to_mt5_timestamp
 from mtdata.core.trading_validation import (
     _normalize_order_type_input,
     _normalize_price_for_symbol,
+    _retcode_is_done,
+    _trade_done_codes,
     _validate_live_protection_levels,
     _validate_deviation,
     _validate_volume,
@@ -52,6 +54,19 @@ def test_validate_deviation_rejects_negative_and_non_numeric():
     value, error = _validate_deviation("abc")
     assert value is None
     assert error == "deviation must be numeric"
+
+
+def test_trade_done_helpers_use_safe_int_attr_and_cached_codes():
+    mt5 = SimpleNamespace(
+        TRADE_RETCODE_DONE=True,
+        TRADE_RETCODE_DONE_PARTIAL="10010",
+    )
+
+    done_codes = _trade_done_codes(mt5)
+
+    assert done_codes == {10009, 10010}
+    assert _retcode_is_done(mt5, "10010", done_codes) is True
+    assert _retcode_is_done(mt5, 1, done_codes) is False
 
 
 def test_normalize_price_for_symbol_accepts_negative_non_zero_values():


### PR DESCRIPTION
## Summary
- centralize the duplicated trade-success retcode helpers in `trading_validation.py`
- update both `trading_orders.py` and `trading_execution.py` to use the shared implementation
- add a regression that locks the shared helper onto `_safe_int_attr()` semantics and the cached `done_codes` path

## Root cause
`trading_orders.py` and `trading_execution.py` each carried their own `_trade_done_codes()` / `_retcode_is_done()` pair. The two copies were already drifting: one used `_safe_int_attr()` while the other used direct `getattr()` coercion, so malformed MT5 constants could be interpreted differently in two execution paths.

## Implemented solution
- move the shared done-retcode helpers into `src/mtdata/core/trading_validation.py`
- update the order-placement and execution flows to call the shared helper instead of their local copies
- add a focused regression that proves malformed MT5 constants still fall back through `_safe_int_attr()` and that the optional cached `done_codes` path remains valid

## Trade-offs / limitations
This is a behavior-preserving dedupe for the existing done-retcode semantics. The broader order-scaffold duplication report remains separate because it is a larger extraction than this helper-level cleanup.

## Report
Resolves local report `code-reports/to-do/MED_duplicate-trading-functions.md`.