### PR TITLE
Remove unused spectral TV import

### DIFF
--- a/src/mtdata/utils/denoise/filters/spectral.py
+++ b/src/mtdata/utils/denoise/filters/spectral.py
@@ -2,7 +2,6 @@
 from typing import Any, Dict, Optional
 import pandas as pd
 import numpy as np
-from skimage.restoration import denoise_tv_chambolle as _denoise_tv_chambolle
 
 try:
     from scipy.signal import butter as _butter


### PR DESCRIPTION
## Summary
- remove the unused `denoise_tv_chambolle` import from `utils/denoise/filters/spectral.py`
- keep the actual TV denoiser implementation in `specialized.py`

## Root cause
`spectral.py` carried a leftover import of the total-variation denoiser even though the module only registers FFT and Butterworth filters. The real TV-denoise implementation already lives in `specialized.py`, so the spectral import was dead code and an unnecessary dependency edge.

## Implemented solution
- delete the unused `skimage.restoration.denoise_tv_chambolle` import from the spectral filter module
- leave the filter registrations and runtime behavior otherwise unchanged

## Trade-offs / limitations
This is a pure cleanup. It does not change any denoise algorithms or registration behavior.

## Report
Resolves local report `code-reports/to-do/LOW_spectral-unused-tv-import.md`.