### PR TITLE
Remove duplicate regex import

### DIFF
--- a/src/mtdata/utils/indicators.py
+++ b/src/mtdata/utils/indicators.py
@@ -246,7 +246,6 @@ def _parse_ti_specs(spec: str) -> List[Tuple[str, List[int | float], Dict[str, i
                     if num is not None:
                         args.append(num)
         # Flex: detect trailing number in name (EMA21 -> length=21)
-        import re
         normalized_name = _normalize_ta_indicator_name(name.strip())
         m = re.search(r"(.*?)[_\-]?([0-9]{1,3})$", name)
         if (


### PR DESCRIPTION
## Summary
- remove the redundant local `re` import from `_parse_ti_specs()` in `utils/indicators.py`
- keep the parser behavior unchanged by relying on the existing module-level import

## Root cause
`utils/indicators.py` already imported `re` at module scope, but `_parse_ti_specs()` repeated the import inside the loop that normalizes compact indicator names like `EMA21`. That extra import was dead code and suggested the parser needed a special local scope when it did not.

## Implemented solution
- delete the inner `import re` from `_parse_ti_specs()`
- leave the parsing logic untouched so the existing name/parameter normalization behavior stays the same

## Trade-offs / limitations
This is a cosmetic cleanup only; it does not change indicator parsing behavior.

## Report
Resolves local report `code-reports/to-do/LOW_duplicate-re-import.md`.