### PR TITLE
Remove duplicate NumPy import

### DIFF
--- a/src/mtdata/forecast/common.py
+++ b/src/mtdata/forecast/common.py
@@ -107,8 +107,6 @@ def _extract_forecast_values(Yf: Any, fh: int, method_name: str = "forecast") ->
     
     Common logic for finding prediction columns and extracting values.
     """
-    import numpy as np
-    
     # Find the prediction column
     pred_col = None
     try:


### PR DESCRIPTION
## Summary
- remove the redundant inner `numpy` import from `_extract_forecast_values()` in `forecast/common.py`
- keep the helper behavior unchanged by relying on the existing module-level `np` import

## Root cause
`forecast/common.py` already imported `numpy as np` at module scope, but `_extract_forecast_values()` repeated the import inside the helper body. That second import was unnecessary and made the helper look like it needed a special local dependency when it did not.

## Implemented solution
- delete the inner `import numpy as np` from `_extract_forecast_values()`
- leave the forecast-column selection and edge-padding logic unchanged

## Trade-offs / limitations
This is a cleanup-only change. It does not alter forecast extraction behavior.

## Report
Resolves local report `code-reports/to-do/LOW_redundant-numpy-import.md`.