### PR TITLE
Reuse shared timeframe error formatter

### DIFF
--- a/src/mtdata/core/trading_time.py
+++ b/src/mtdata/core/trading_time.py
@@ -10,6 +10,7 @@ from typing import Optional, Tuple, Union
 
 from .config import mt5_config
 from ..shared.constants import TIMEFRAME_SECONDS
+from ..shared.validators import unsupported_timeframe_seconds_error
 
 
 ExpirationValue = Union[int, float, str, datetime]
@@ -139,7 +140,7 @@ def _next_candle_close_server_time(timeframe: str, *, now_utc: Optional[datetime
 
     interval_seconds = int(TIMEFRAME_SECONDS[tf])
     if interval_seconds <= 0:
-        raise ValueError(f"Unsupported timeframe seconds for {tf}")
+        raise ValueError(unsupported_timeframe_seconds_error(tf))
 
     day_start = server_now.replace(hour=0, minute=0, second=0, microsecond=0)
     elapsed_seconds = max(0.0, (server_now - day_start).total_seconds())

--- a/src/mtdata/forecast/barriers_probabilities.py
+++ b/src/mtdata/forecast/barriers_probabilities.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from ..shared.schema import TimeframeLiteral, DenoiseSpec
 from ..shared.constants import TIMEFRAME_SECONDS
+from ..shared.validators import unsupported_timeframe_seconds_error
 from .common import fetch_history as _fetch_history, log_returns_from_prices as _log_returns_from_prices
 from ..utils.utils import parse_kv_or_json as _parse_kv_or_json
 from ..utils.barriers import (
@@ -402,7 +403,7 @@ def forecast_barrier_closed_form(
             return {"error": "Provide a positive barrier price"}
         tf_secs = TIMEFRAME_SECONDS.get(timeframe, 0)
         if not tf_secs:
-            return {"error": f"Unsupported timeframe seconds for {timeframe}"}
+            return {"error": unsupported_timeframe_seconds_error(timeframe)}
         T = float(tf_secs * int(horizon)) / (365.0 * 24.0 * 3600.0)
         if mu is None or sigma is None:
             with np.errstate(divide='ignore', invalid='ignore'):

--- a/tests/core/test_wait_candle.py
+++ b/tests/core/test_wait_candle.py
@@ -46,6 +46,21 @@ def test_next_candle_close_server_time_handles_weekly_boundary(utc_server_clock)
     assert result == datetime(2026, 3, 16, 0, 0, 0)
 
 
+def test_next_candle_close_server_time_uses_shared_unsupported_timeframe_error(
+    utc_server_clock,
+    monkeypatch,
+) -> None:
+    monkeypatch.setitem(trading_time.TIMEFRAME_SECONDS, "M5", 0)
+    monkeypatch.setattr(
+        trading_time,
+        "unsupported_timeframe_seconds_error",
+        lambda timeframe: f"custom unsupported {timeframe}",
+    )
+
+    with pytest.raises(ValueError, match="custom unsupported M5"):
+        _next_candle_close_server_time("M5", now_utc=datetime(2026, 3, 13, 10, 2, 10, tzinfo=timezone.utc))
+
+
 def test_sleep_until_next_candle_returns_expected_wait(utc_server_clock) -> None:
     slept = []
 

--- a/tests/forecast/test_forecast_barriers.py
+++ b/tests/forecast/test_forecast_barriers.py
@@ -1977,6 +1977,22 @@ class TestTier1StructuredErrorHandling(_BarrierModulePatchMixin, unittest.TestCa
         self.assertIn("error_type", result)
         self.assertIn("traceback_summary", result)
 
+    def test_closed_form_uses_shared_unsupported_timeframe_error(self):
+        with patch.dict(f"{_BARRIER_PROB_ROOT}.TIMEFRAME_SECONDS", {"H1": 0}, clear=False):
+            with patch(
+                f"{_BARRIER_PROB_ROOT}.unsupported_timeframe_seconds_error",
+                return_value="custom timeframe error",
+            ):
+                result = forecast_barrier_closed_form(
+                    symbol="EURUSD",
+                    timeframe="H1",
+                    horizon=10,
+                    direction="long",
+                    barrier=1.1,
+                )
+
+        self.assertEqual(result["error"], "custom timeframe error")
+
     def test_probabilities_reject_non_finite_trailing_close_without_live_reference(self):
         dates = pd.date_range(start='2023-01-01', periods=500, freq='h')
         prices = np.full(500, 1.0)


### PR DESCRIPTION
## Summary
- reuse `unsupported_timeframe_seconds_error()` in the remaining inline call sites
- add focused regressions proving the trading and barrier paths now route through the shared formatter

## Root cause
The shared timeframe validation formatter already existed in `shared/validators.py`, but `core/trading_time.py` and the closed-form path in `forecast/barriers_probabilities.py` still rebuilt the same message inline. That left identical validation text duplicated across modules instead of flowing through one helper.

## Implemented solution
- import and use `unsupported_timeframe_seconds_error()` in `trading_time.py`
- import and use the same helper in the closed-form barrier probability path
- add targeted tests that monkeypatch the shared formatter and force the unsupported-seconds branch, proving both call sites reuse the helper

## Trade-offs / limitations
This keeps the existing error text and behavior the same. The change is limited to helper reuse and regression coverage.

## Report
Resolves local report `code-reports/to-do/LOW_Duplicate_error_messages.md`.