### PR TITLE
Simplify flag completion estimate

### DIFF
--- a/src/mtdata/core/patterns_support.py
+++ b/src/mtdata/core/patterns_support.py
@@ -1238,7 +1238,7 @@ def _estimate_classic_bars_to_completion(
             bars = int(max(0, int(round(t_star - (n_bars - 1)))))
             return int(min(max(0, bars), 3 * length))
         if "pennant" in name_text or "flag" in name_text:
-            return int(max(1, min(2 * length, int(round(0.3 * length)))))
+            return int(max(1, int(round(0.3 * length))))
     except Exception:
         return None
     return None

--- a/tests/patterns/test_patterns_core_coverage.py
+++ b/tests/patterns/test_patterns_core_coverage.py
@@ -639,7 +639,7 @@ class TestEstimateClassicBarsToCompletion:
 
     def test_flag(self):
         result = self._call("Bull Flag", {}, 0, 20, 100)
-        assert isinstance(result, int)
+        assert result == 6
 
     def test_unknown_pattern(self):
         result = self._call("Unknown Pattern", {}, 0, 20, 100)


### PR DESCRIPTION
## Summary
- simplify the flag/pennant completion estimate in `patterns_support.py`
- tighten the helper regression to assert the exact returned estimate for a representative flag input

## Root cause
The flag/pennant completion estimate wrapped `int(round(0.3 * length))` in `min(2 * length, ...)`, but that cap could never win for any positive pattern length. The code therefore carried an unreachable bound that made the helper look more constrained than it actually was.

## Implemented solution
- remove the dead `2 * length` cap from the flag/pennant estimate branch
- update the pattern helper test to assert the concrete result produced for a representative flag length

## Trade-offs / limitations
This is a behavior-preserving simplification only; the returned estimates stay the same.

## Report
Resolves local report `code-reports/to-do/LOW_patterns-completion-estimate-dead-bound.md`.