### PR TITLE
Fast-path flat SSA inputs

### DIFF
--- a/src/mtdata/utils/denoise/filters/decomposition.py
+++ b/src/mtdata/utils/denoise/filters/decomposition.py
@@ -28,6 +28,9 @@ def _ssa_denoise(
     n = len(x)
     if n < 4:
         return x
+    series_variance = float(np.var(x))
+    if math.isfinite(series_variance) and series_variance <= 0.0:
+        return x.copy()
     L = max(2, int(window))
     if L >= n:
         return x

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -823,6 +823,16 @@ class TestSsaDenoise:
         y = _ssa_denoise(np.zeros(20, dtype=float), window=5, components=0.9)
         np.testing.assert_array_equal(y, np.zeros(20, dtype=float))
 
+    def test_constant_series_skips_svd(self, monkeypatch):
+        monkeypatch.setattr(
+            "mtdata.utils.denoise.filters.decomposition.np.linalg.svd",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("svd should be skipped")),
+        )
+
+        y = _ssa_denoise(np.full(20, 5.0, dtype=float), window=5, components=0.9)
+
+        np.testing.assert_array_equal(y, np.full(20, 5.0, dtype=float))
+
 
 class TestL1TrendFilter:
     def test_basic(self):


### PR DESCRIPTION
## Summary
- add a flat-series fast path to `_ssa_denoise()` so constant inputs return before building the trajectory matrix and running SVD
- add a regression that proves constant-series SSA skips the SVD call

## Root cause
`_ssa_denoise()` only discovered the zero-energy case after constructing the SSA trajectory matrix and running `np.linalg.svd()`. For flat inputs, that meant paying the most expensive part of the algorithm before returning an effectively unchanged result.

## Implemented solution
- detect zero-variance finite inputs up front in `_ssa_denoise()` and return a copy immediately
- keep the existing post-SVD total-energy guard as a fallback for non-finite or other degenerate cases
- add a focused regression that patches `np.linalg.svd` to fail, proving the flat-series path returns before SVD

## Trade-offs / limitations
The optimization targets exactly constant-series inputs. Non-constant low-energy series still follow the existing SSA path.

## Report
Resolves local report `code-reports/to-do/LOW_ssa-zero-energy-edge-case.md`.