### PR TITLE
Share Finviz helper implementations

### DIFF
--- a/src/mtdata/services/finviz/api.py
+++ b/src/mtdata/services/finviz/api.py
@@ -5,17 +5,17 @@ from typing import Any, Dict, List, Optional, Literal
 import importlib
 
 from .client import (
-    _FINVIZ_HTTP_TIMEOUT as _DEFAULT_FINVIZ_HTTP_TIMEOUT,
-    _FINVIZ_PAGE_LIMIT_MAX as _DEFAULT_FINVIZ_PAGE_LIMIT_MAX,
-    _FINVIZ_SCREENER_MAX_ROWS as _DEFAULT_FINVIZ_SCREENER_MAX_ROWS,
+    get_finviz_http_timeout,
+    get_finviz_page_limit_max,
+    get_finviz_screener_max_rows,
 )
 
 logger = logging.getLogger(__name__)
 
 # Configuration constants
-_FINVIZ_HTTP_TIMEOUT = _DEFAULT_FINVIZ_HTTP_TIMEOUT
-_FINVIZ_SCREENER_MAX_ROWS = _DEFAULT_FINVIZ_SCREENER_MAX_ROWS
-_FINVIZ_PAGE_LIMIT_MAX = _DEFAULT_FINVIZ_PAGE_LIMIT_MAX
+_FINVIZ_HTTP_TIMEOUT = get_finviz_http_timeout()
+_FINVIZ_SCREENER_MAX_ROWS = get_finviz_screener_max_rows()
+_FINVIZ_PAGE_LIMIT_MAX = get_finviz_page_limit_max()
 
 
 def _sanitize_pagination(limit: int, page: int) -> tuple[int, int]:

--- a/src/mtdata/services/finviz/api.py
+++ b/src/mtdata/services/finviz/api.py
@@ -2,41 +2,39 @@
 import logging
 import datetime
 from typing import Any, Dict, List, Optional, Literal
-import os
-import threading
 import importlib
-import requests
+
+from .client import (
+    _FINVIZ_HTTP_TIMEOUT as _DEFAULT_FINVIZ_HTTP_TIMEOUT,
+    _FINVIZ_PAGE_LIMIT_MAX as _DEFAULT_FINVIZ_PAGE_LIMIT_MAX,
+    _FINVIZ_SCREENER_MAX_ROWS as _DEFAULT_FINVIZ_SCREENER_MAX_ROWS,
+)
 
 logger = logging.getLogger(__name__)
 
 # Configuration constants
-_FINVIZ_HTTP_TIMEOUT = float(os.getenv("FINVIZ_HTTP_TIMEOUT", "15"))
-_FINVIZ_SCREENER_MAX_ROWS = int(os.getenv("FINVIZ_SCREENER_MAX_ROWS", "5000"))
-_FINVIZ_PAGE_LIMIT_MAX = int(os.getenv("FINVIZ_PAGE_LIMIT_MAX", "500"))
-_FINVIZ_HTTP_SESSION: Optional[requests.Session] = None
-_FINVIZ_HTTP_SESSION_LOCK = threading.Lock()
+_FINVIZ_HTTP_TIMEOUT = _DEFAULT_FINVIZ_HTTP_TIMEOUT
+_FINVIZ_SCREENER_MAX_ROWS = _DEFAULT_FINVIZ_SCREENER_MAX_ROWS
+_FINVIZ_PAGE_LIMIT_MAX = _DEFAULT_FINVIZ_PAGE_LIMIT_MAX
 
 
 def _sanitize_pagination(limit: int, page: int) -> tuple[int, int]:
     """Clamp pagination inputs to sane bounds."""
-    try:
-        safe_limit = int(limit)
-    except Exception:
-        safe_limit = 50
-    try:
-        safe_page = int(page)
-    except Exception:
-        safe_page = 1
-    safe_limit = max(1, min(_FINVIZ_PAGE_LIMIT_MAX, safe_limit))
-    safe_page = max(1, safe_page)
-    return safe_limit, safe_page
+    from .pagination import sanitize_pagination
+
+    return sanitize_pagination(limit, page, page_limit_max=_FINVIZ_PAGE_LIMIT_MAX)
 
 
 def _compute_screener_fetch_limit(limit: int, page: int, max_rows: int) -> int:
     """Rows to fetch from finvizfinance screener to satisfy current page safely."""
-    safe_limit, safe_page = _sanitize_pagination(limit, page)
-    needed = safe_limit * safe_page
-    return max(1, min(max_rows, needed))
+    from .pagination import compute_screener_fetch_limit
+
+    return compute_screener_fetch_limit(
+        limit,
+        page,
+        max_rows,
+        page_limit_max=_FINVIZ_PAGE_LIMIT_MAX,
+    )
 
 
 def _paginate_finviz_records(
@@ -45,20 +43,14 @@ def _paginate_finviz_records(
     limit: int,
     page: int,
 ) -> tuple[List[Any], int, int, int, int]:
-    safe_limit, safe_page = _sanitize_pagination(limit, page)
-    total = len(items) if items is not None else 0
-    start_idx = (safe_page - 1) * safe_limit
-    end_idx = start_idx + safe_limit
+    from .pagination import paginate_finviz_records
 
-    if hasattr(items, "iloc"):
-        rows = items.iloc[start_idx:end_idx].to_dict(orient="records")
-    elif isinstance(items, list):
-        rows = items[start_idx:end_idx]
-    else:
-        rows = []
-
-    pages = 0 if total <= 0 else (total + safe_limit - 1) // safe_limit
-    return rows, total, safe_limit, safe_page, pages
+    return paginate_finviz_records(
+        items,
+        limit=limit,
+        page=page,
+        page_limit_max=_FINVIZ_PAGE_LIMIT_MAX,
+    )
 
 
 def _normalize_finviz_date_string(value: Any) -> Any:
@@ -114,24 +106,28 @@ def _run_screener_view(
     page: int = 1,
 ) -> Any:
     """Run screener_view with bounded rows and no inter-page sleep."""
-    fetch_limit = _compute_screener_fetch_limit(limit=limit, page=page, max_rows=_FINVIZ_SCREENER_MAX_ROWS)
-    return screener.screener_view(order=order, limit=fetch_limit, verbose=0, sleep_sec=0), fetch_limit
+    from .pagination import run_screener_view
+
+    return run_screener_view(
+        screener,
+        order=order,
+        limit=limit,
+        page=page,
+        screener_max_rows=_FINVIZ_SCREENER_MAX_ROWS,
+        page_limit_max=_FINVIZ_PAGE_LIMIT_MAX,
+    )
 
 
 def _finviz_http_get(url: str, *, headers: Dict[str, str], params: Dict[str, Any]) -> Any:
     """HTTP GET helper with centralized timeout and pooled connections."""
-    # Testability: when requests.get is monkeypatched, honor that hook.
-    if requests.get is not requests.api.get:
-        return requests.get(url, headers=headers, params=params, timeout=_FINVIZ_HTTP_TIMEOUT)
+    from .client import finviz_http_get
 
-    global _FINVIZ_HTTP_SESSION
-    if _FINVIZ_HTTP_SESSION is None:
-        with _FINVIZ_HTTP_SESSION_LOCK:
-            if _FINVIZ_HTTP_SESSION is None:
-                session = requests.Session()
-                session.headers.update({"User-Agent": "Mozilla/5.0"})
-                _FINVIZ_HTTP_SESSION = session
-    return _FINVIZ_HTTP_SESSION.get(url, headers=headers, params=params, timeout=_FINVIZ_HTTP_TIMEOUT)
+    return finviz_http_get(
+        url,
+        headers=headers,
+        params=params,
+        timeout=_FINVIZ_HTTP_TIMEOUT,
+    )
 
 
 def _apply_finvizfinance_timeout_patch() -> None:

--- a/src/mtdata/services/finviz/client.py
+++ b/src/mtdata/services/finviz/client.py
@@ -1,4 +1,5 @@
 """HTTP client and session management for Finviz service."""
+import math
 import os
 import threading
 from typing import Any, Dict, Optional
@@ -12,6 +13,35 @@ _FINVIZ_PAGE_LIMIT_MAX = int(os.getenv("FINVIZ_PAGE_LIMIT_MAX", "500"))
 # Thread-safe HTTP session
 _FINVIZ_HTTP_SESSION: Optional[requests.Session] = None
 _FINVIZ_HTTP_SESSION_LOCK = threading.Lock()
+
+
+def _normalize_timeout_value(timeout: Any) -> float | tuple[float, float]:
+    default_timeout = float(_FINVIZ_HTTP_TIMEOUT)
+    if timeout is None:
+        return default_timeout
+    if isinstance(timeout, (list, tuple)):
+        if len(timeout) != 2:
+            return default_timeout
+        try:
+            connect_timeout = float(timeout[0])
+            read_timeout = float(timeout[1])
+        except Exception:
+            return default_timeout
+        if (
+            not math.isfinite(connect_timeout)
+            or not math.isfinite(read_timeout)
+            or connect_timeout <= 0.0
+            or read_timeout <= 0.0
+        ):
+            return default_timeout
+        return (connect_timeout, read_timeout)
+    try:
+        timeout_value = float(timeout)
+    except Exception:
+        return default_timeout
+    if not math.isfinite(timeout_value) or timeout_value <= 0.0:
+        return default_timeout
+    return timeout_value
 
 
 def get_finviz_http_timeout() -> float:
@@ -34,10 +64,10 @@ def finviz_http_get(
     *,
     headers: Dict[str, str],
     params: Dict[str, Any],
-    timeout: Optional[float] = None,
+    timeout: Optional[Any] = None,
 ) -> Any:
     """HTTP GET helper with centralized timeout and pooled connections."""
-    timeout_value = _FINVIZ_HTTP_TIMEOUT if timeout is None else float(timeout)
+    timeout_value = _normalize_timeout_value(timeout)
     # Testability: when requests.get is monkeypatched, honor that hook.
     if requests.get is not requests.api.get:
         return requests.get(url, headers=headers, params=params, timeout=timeout_value)

--- a/src/mtdata/services/finviz/client.py
+++ b/src/mtdata/services/finviz/client.py
@@ -29,11 +29,18 @@ def get_finviz_page_limit_max() -> int:
     return _FINVIZ_PAGE_LIMIT_MAX
 
 
-def finviz_http_get(url: str, *, headers: Dict[str, str], params: Dict[str, Any]) -> Any:
+def finviz_http_get(
+    url: str,
+    *,
+    headers: Dict[str, str],
+    params: Dict[str, Any],
+    timeout: Optional[float] = None,
+) -> Any:
     """HTTP GET helper with centralized timeout and pooled connections."""
+    timeout_value = _FINVIZ_HTTP_TIMEOUT if timeout is None else float(timeout)
     # Testability: when requests.get is monkeypatched, honor that hook.
     if requests.get is not requests.api.get:
-        return requests.get(url, headers=headers, params=params, timeout=_FINVIZ_HTTP_TIMEOUT)
+        return requests.get(url, headers=headers, params=params, timeout=timeout_value)
 
     global _FINVIZ_HTTP_SESSION
     if _FINVIZ_HTTP_SESSION is None:
@@ -42,7 +49,7 @@ def finviz_http_get(url: str, *, headers: Dict[str, str], params: Dict[str, Any]
                 session = requests.Session()
                 session.headers.update({"User-Agent": "Mozilla/5.0"})
                 _FINVIZ_HTTP_SESSION = session
-    return _FINVIZ_HTTP_SESSION.get(url, headers=headers, params=params, timeout=_FINVIZ_HTTP_TIMEOUT)
+    return _FINVIZ_HTTP_SESSION.get(url, headers=headers, params=params, timeout=timeout_value)
 
 
 def reset_finviz_http_session() -> None:

--- a/src/mtdata/services/finviz/pagination.py
+++ b/src/mtdata/services/finviz/pagination.py
@@ -1,10 +1,15 @@
 """Pagination utilities for Finviz service."""
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from .client import get_finviz_page_limit_max, get_finviz_screener_max_rows
 
 
-def sanitize_pagination(limit: int, page: int) -> Tuple[int, int]:
+def sanitize_pagination(
+    limit: int,
+    page: int,
+    *,
+    page_limit_max: Optional[int] = None,
+) -> Tuple[int, int]:
     """Clamp pagination inputs to sane bounds."""
     try:
         safe_limit = int(limit)
@@ -14,14 +19,21 @@ def sanitize_pagination(limit: int, page: int) -> Tuple[int, int]:
         safe_page = int(page)
     except Exception:
         safe_page = 1
-    safe_limit = max(1, min(get_finviz_page_limit_max(), safe_limit))
+    max_page_limit = get_finviz_page_limit_max() if page_limit_max is None else int(page_limit_max)
+    safe_limit = max(1, min(max_page_limit, safe_limit))
     safe_page = max(1, safe_page)
     return safe_limit, safe_page
 
 
-def compute_screener_fetch_limit(limit: int, page: int, max_rows: int) -> int:
+def compute_screener_fetch_limit(
+    limit: int,
+    page: int,
+    max_rows: int,
+    *,
+    page_limit_max: Optional[int] = None,
+) -> int:
     """Rows to fetch from finvizfinance screener to satisfy current page safely."""
-    safe_limit, safe_page = sanitize_pagination(limit, page)
+    safe_limit, safe_page = sanitize_pagination(limit, page, page_limit_max=page_limit_max)
     needed = safe_limit * safe_page
     return max(1, min(max_rows, needed))
 
@@ -31,9 +43,10 @@ def paginate_finviz_records(
     *,
     limit: int,
     page: int,
+    page_limit_max: Optional[int] = None,
 ) -> Tuple[List[Any], int, int, int, int]:
     """Paginate a list or DataFrame of Finviz records."""
-    safe_limit, safe_page = sanitize_pagination(limit, page)
+    safe_limit, safe_page = sanitize_pagination(limit, page, page_limit_max=page_limit_max)
     total = len(items) if items is not None else 0
     start_idx = (safe_page - 1) * safe_limit
     end_idx = start_idx + safe_limit
@@ -55,10 +68,16 @@ def run_screener_view(
     order: str = "Ticker",
     limit: int = 50,
     page: int = 1,
+    screener_max_rows: Optional[int] = None,
+    page_limit_max: Optional[int] = None,
 ) -> Tuple[Any, int]:
     """Run screener_view with bounded rows and no inter-page sleep."""
+    max_rows = get_finviz_screener_max_rows() if screener_max_rows is None else int(screener_max_rows)
     fetch_limit = compute_screener_fetch_limit(
-        limit=limit, page=page, max_rows=get_finviz_screener_max_rows()
+        limit=limit,
+        page=page,
+        max_rows=max_rows,
+        page_limit_max=page_limit_max,
     )
     return screener.screener_view(order=order, limit=fetch_limit, verbose=0, sleep_sec=0), fetch_limit
 

--- a/src/mtdata/services/finviz/pagination.py
+++ b/src/mtdata/services/finviz/pagination.py
@@ -4,6 +4,16 @@ from typing import Any, List, Optional, Tuple
 from .client import get_finviz_page_limit_max, get_finviz_screener_max_rows
 
 
+def _coerce_positive_int(value: Any, *, default: int) -> int:
+    if isinstance(value, bool):
+        return int(default)
+    try:
+        numeric = int(value)
+    except Exception:
+        return int(default)
+    return max(1, int(numeric))
+
+
 def sanitize_pagination(
     limit: int,
     page: int,
@@ -19,7 +29,10 @@ def sanitize_pagination(
         safe_page = int(page)
     except Exception:
         safe_page = 1
-    max_page_limit = get_finviz_page_limit_max() if page_limit_max is None else int(page_limit_max)
+    max_page_limit = _coerce_positive_int(
+        get_finviz_page_limit_max() if page_limit_max is None else page_limit_max,
+        default=get_finviz_page_limit_max(),
+    )
     safe_limit = max(1, min(max_page_limit, safe_limit))
     safe_page = max(1, safe_page)
     return safe_limit, safe_page
@@ -34,8 +47,12 @@ def compute_screener_fetch_limit(
 ) -> int:
     """Rows to fetch from finvizfinance screener to satisfy current page safely."""
     safe_limit, safe_page = sanitize_pagination(limit, page, page_limit_max=page_limit_max)
+    safe_max_rows = _coerce_positive_int(
+        get_finviz_screener_max_rows() if max_rows is None else max_rows,
+        default=get_finviz_screener_max_rows(),
+    )
     needed = safe_limit * safe_page
-    return max(1, min(max_rows, needed))
+    return max(1, min(safe_max_rows, needed))
 
 
 def paginate_finviz_records(
@@ -72,7 +89,10 @@ def run_screener_view(
     page_limit_max: Optional[int] = None,
 ) -> Tuple[Any, int]:
     """Run screener_view with bounded rows and no inter-page sleep."""
-    max_rows = get_finviz_screener_max_rows() if screener_max_rows is None else int(screener_max_rows)
+    max_rows = _coerce_positive_int(
+        get_finviz_screener_max_rows() if screener_max_rows is None else screener_max_rows,
+        default=get_finviz_screener_max_rows(),
+    )
     fetch_limit = compute_screener_fetch_limit(
         limit=limit,
         page=page,

--- a/tests/services/test_finviz_service_hardening.py
+++ b/tests/services/test_finviz_service_hardening.py
@@ -4,6 +4,8 @@ import types
 import pandas as pd
 
 from mtdata.services import finviz as svc
+from mtdata.services.finviz import client as finviz_client
+from mtdata.services.finviz import pagination as finviz_pagination
 
 
 def test_compute_screener_fetch_limit_is_bounded(monkeypatch):
@@ -36,6 +38,69 @@ def test_finviz_http_get_applies_default_timeout(monkeypatch):
 
     assert calls["url"] == "https://example.test"
     assert calls["timeout"] == 7.5
+
+
+def test_finviz_http_get_accepts_requests_timeout_tuple(monkeypatch):
+    calls = {}
+
+    class DummyResp:
+        pass
+
+    def _fake_get(url, headers=None, params=None, timeout=None):
+        calls["timeout"] = timeout
+        return DummyResp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+    _ = finviz_client.finviz_http_get(
+        "https://example.test",
+        headers={"A": "B"},
+        params={"x": 1},
+        timeout=(1.5, 3.0),
+    )
+
+    assert calls["timeout"] == (1.5, 3.0)
+
+
+def test_finviz_http_get_invalid_timeout_override_falls_back(monkeypatch):
+    calls = {}
+
+    class DummyResp:
+        pass
+
+    def _fake_get(url, headers=None, params=None, timeout=None):
+        calls["timeout"] = timeout
+        return DummyResp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+    monkeypatch.setattr(finviz_client, "_FINVIZ_HTTP_TIMEOUT", 7.5)
+    _ = finviz_client.finviz_http_get(
+        "https://example.test",
+        headers={"A": "B"},
+        params={"x": 1},
+        timeout="bad-timeout",
+    )
+
+    assert calls["timeout"] == 7.5
+
+
+def test_pagination_helpers_coerce_invalid_override_values(monkeypatch):
+    monkeypatch.setattr(finviz_pagination, "get_finviz_page_limit_max", lambda: 500)
+    monkeypatch.setattr(finviz_pagination, "get_finviz_screener_max_rows", lambda: 120)
+
+    assert finviz_pagination.sanitize_pagination("bad", 0, page_limit_max="bad") == (50, 1)
+    assert (
+        finviz_pagination.compute_screener_fetch_limit(
+            limit=50,
+            page=3,
+            max_rows="bad",
+            page_limit_max="bad",
+        )
+        == 120
+    )
 
 
 def test_screen_stocks_uses_bounded_screener_view(monkeypatch):


### PR DESCRIPTION
## Summary
- replace the duplicate Finviz HTTP-session and pagination helper bodies in `api.py` with thin wrappers over `client.py` and `pagination.py`
- keep the canonical package API and monkeypatch-friendly package-level constants unchanged

## Root cause
The Finviz package had already split HTTP-session and pagination logic into `client.py` and `pagination.py`, but `api.py` still carried full local copies of the same code. That meant the shared modules and the canonical API module could drift independently even though they were supposed to represent the same behavior.

## Implemented solution
- extend `client.finviz_http_get()` so callers can supply an explicit timeout override while reusing the shared pooled-session implementation
- extend the pagination helpers so callers can supply explicit page-limit and screener-row bounds while keeping their existing default behavior
- replace the duplicate implementations in `api.py` with thin wrappers that pass the canonical package-level Finviz settings through to the shared helpers

## Trade-offs / limitations
This refactor intentionally leaves the broader utility-helper duplication alone because those similarly named helpers are not exact behavioral matches. The change is limited to the concrete HTTP and pagination duplication validated in the report.

## Report
Resolves local report `code-reports/to-do/MED_finviz-duplicate-code.md`.