### PR TITLE
Accept ISO datetime Finviz dates

### DIFF
--- a/src/mtdata/services/finviz/api.py
+++ b/src/mtdata/services/finviz/api.py
@@ -61,11 +61,15 @@ def _normalize_finviz_date_string(value: Any) -> Any:
     if not text:
         return value
     text = text.replace("’", "'")
-    for fmt in ("%b %d '%y", "%b %d %Y", "%Y-%m-%d"):
+    for fmt in ("%b %d '%y", "%b %d %Y"):
         try:
             return datetime.datetime.strptime(text, fmt).date().isoformat()
         except Exception:
             continue
+    try:
+        return _parse_iso_date_input(text, field_name="date").isoformat()
+    except ValueError:
+        pass
     return value
 
 
@@ -878,12 +882,15 @@ def get_dividends_calendar_api(
 
 def _parse_iso_date_input(value: str, *, field_name: str) -> datetime.date:
     text = str(value).strip()
-    if len(text) < 10:
+    if not text:
         raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime")
-    if len(text) > 10 and text[10] not in {"T", " ", "Z"}:
-        raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime")
+    normalized = text[:-1] + "+00:00" if text.endswith(("Z", "z")) else text
     try:
-        return datetime.date.fromisoformat(text[:10])
+        return datetime.date.fromisoformat(normalized)
+    except ValueError:
+        pass
+    try:
+        return datetime.datetime.fromisoformat(normalized).date()
     except ValueError as e:
         raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime") from e
 

--- a/src/mtdata/services/finviz/api.py
+++ b/src/mtdata/services/finviz/api.py
@@ -876,25 +876,33 @@ def get_dividends_calendar_api(
         return {"error": f"Failed to fetch dividends calendar: {str(e)}"}
 
 
+def _parse_iso_date_input(value: str, *, field_name: str) -> datetime.date:
+    text = str(value).strip()
+    if len(text) < 10:
+        raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime")
+    if len(text) > 10 and text[10] not in {"T", " ", "Z"}:
+        raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime")
+    try:
+        return datetime.date.fromisoformat(text[:10])
+    except ValueError as e:
+        raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime") from e
+
+
 def _resolve_date_range(*, date_from: Optional[str], date_to: Optional[str], default_days: int) -> tuple[str, str]:
     """Resolve an ISO date range for Finviz API calls."""
     if date_to and not date_from:
         raise ValueError("date_from is required when date_to is provided")
 
     if date_from:
-        try:
-            df = datetime.date.fromisoformat(date_from)
-        except ValueError as e:
-            raise ValueError(f"Invalid date_from '{date_from}'. Expected YYYY-MM-DD") from e
+        df = _parse_iso_date_input(date_from, field_name="date_from")
+        date_from = df.isoformat()
     else:
         df = datetime.date.today()
         date_from = df.isoformat()
 
     if date_to:
-        try:
-            dt = datetime.date.fromisoformat(date_to)
-        except ValueError as e:
-            raise ValueError(f"Invalid date_to '{date_to}'. Expected YYYY-MM-DD") from e
+        dt = _parse_iso_date_input(date_to, field_name="date_to")
+        date_to = dt.isoformat()
     else:
         dt = df + datetime.timedelta(days=int(default_days))
         date_to = dt.isoformat()
@@ -907,7 +915,7 @@ def _resolve_date_range(*, date_from: Optional[str], date_to: Optional[str], def
 
 def _align_to_next_monday_if_weekend(date_from: str) -> str:
     """Finviz economic calendar API appears to anchor by week; weekend anchors often return the prior week."""
-    df = datetime.date.fromisoformat(date_from)
+    df = _parse_iso_date_input(date_from, field_name="date_from")
     wd = df.weekday()  # Monday=0 ... Sunday=6
     if wd == 5:  # Saturday
         df = df + datetime.timedelta(days=2)

--- a/src/mtdata/services/finviz/dates.py
+++ b/src/mtdata/services/finviz/dates.py
@@ -3,6 +3,23 @@ import datetime
 from typing import Any, Dict, List, Optional
 
 
+def parse_iso_date_input(value: Any, *, field_name: str) -> datetime.date:
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime")
+    normalized = text[:-1] + "+00:00" if text.endswith(("Z", "z")) else text
+    try:
+        return datetime.date.fromisoformat(normalized)
+    except ValueError:
+        pass
+    try:
+        return datetime.datetime.fromisoformat(normalized).date()
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {field_name} '{value}'. Expected YYYY-MM-DD or ISO datetime"
+        ) from exc
+
+
 def normalize_finviz_date_string(value: Any) -> Any:
     """Normalize Finviz short dates like `Nov 07 '25` to ISO 8601."""
     if not isinstance(value, str):
@@ -10,12 +27,16 @@ def normalize_finviz_date_string(value: Any) -> Any:
     text = value.strip()
     if not text:
         return value
-    text = text.replace("'", "'")
-    for fmt in ("%b %d '%y", "%b %d %Y", "%Y-%m-%d"):
+    text = text.replace("’", "'")
+    for fmt in ("%b %d '%y", "%b %d %Y"):
         try:
             return datetime.datetime.strptime(text, fmt).date().isoformat()
         except Exception:
             continue
+    try:
+        return parse_iso_date_input(text, field_name="date").isoformat()
+    except ValueError:
+        pass
     return value
 
 
@@ -60,12 +81,12 @@ def resolve_date_range(
     """Resolve date range with defaults."""
     today = datetime.date.today()
     if date_from:
-        from_str = str(date_from)
+        from_str = parse_iso_date_input(date_from, field_name="date_from").isoformat()
     else:
         from_date = today - datetime.timedelta(days=default_days)
         from_str = from_date.isoformat()
     if date_to:
-        to_str = str(date_to)
+        to_str = parse_iso_date_input(date_to, field_name="date_to").isoformat()
     else:
         to_str = today.isoformat()
     return from_str, to_str
@@ -73,24 +94,17 @@ def resolve_date_range(
 
 def align_to_next_monday_if_weekend(date_from: str) -> str:
     """Align date to next Monday if it falls on weekend."""
-    try:
-        text = str(date_from).strip()
-        if len(text) < 10:
-            return date_from
-        if len(text) > 10 and text[10] not in {"T", " ", "Z"}:
-            return date_from
-        d = datetime.date.fromisoformat(text[:10])
-        # If Saturday (5) or Sunday (6), move to next Monday
-        if d.weekday() == 5:  # Saturday
-            d = d + datetime.timedelta(days=2)
-        elif d.weekday() == 6:  # Sunday
-            d = d + datetime.timedelta(days=1)
-        return d.isoformat()
-    except Exception:
-        return date_from
+    d = parse_iso_date_input(date_from, field_name="date_from")
+    # If Saturday (5) or Sunday (6), move to next Monday
+    if d.weekday() == 5:  # Saturday
+        d = d + datetime.timedelta(days=2)
+    elif d.weekday() == 6:  # Sunday
+        d = d + datetime.timedelta(days=1)
+    return d.isoformat()
 
 
 __all__ = [
+    "parse_iso_date_input",
     "normalize_finviz_date_string",
     "normalize_finviz_dates_in_rows",
     "strip_string_fields_in_rows",

--- a/src/mtdata/services/finviz/dates.py
+++ b/src/mtdata/services/finviz/dates.py
@@ -74,7 +74,12 @@ def resolve_date_range(
 def align_to_next_monday_if_weekend(date_from: str) -> str:
     """Align date to next Monday if it falls on weekend."""
     try:
-        d = datetime.date.fromisoformat(date_from)
+        text = str(date_from).strip()
+        if len(text) < 10:
+            return date_from
+        if len(text) > 10 and text[10] not in {"T", " ", "Z"}:
+            return date_from
+        d = datetime.date.fromisoformat(text[:10])
         # If Saturday (5) or Sunday (6), move to next Monday
         if d.weekday() == 5:  # Saturday
             d = d + datetime.timedelta(days=2)

--- a/tests/services/test_finviz.py
+++ b/tests/services/test_finviz.py
@@ -378,6 +378,23 @@ class TestFinvizService:
         _, kwargs = mock_fetch_items.call_args
         assert kwargs["date_from"] == "2025-01-06"
 
+    @patch("mtdata.services.finviz._fetch_finviz_economic_calendar_items")
+    def test_get_economic_calendar_accepts_iso_datetime_date_from(self, mock_fetch_items):
+        """ISO datetime date_from inputs should normalize before weekend alignment."""
+        from mtdata.services.finviz import get_economic_calendar
+
+        mock_fetch_items.return_value = []
+
+        result = get_economic_calendar(date_from="2025-01-05T08:30:00", limit=10, page=1)
+
+        assert result["success"] is True
+        assert result["dateFrom"] == "2025-01-05"
+        assert result["dateTo"] == "2025-01-12"
+
+        _, kwargs = mock_fetch_items.call_args
+        assert kwargs["date_from"] == "2025-01-06"
+        assert kwargs["date_to"] == "2025-01-12"
+
     @patch("mtdata.services.finviz._fetch_finviz_calendar_paged")
     def test_get_earnings_calendar_api_success(self, mock_fetch_paged):
         """Test earnings calendar API fetch."""

--- a/tests/services/test_finviz_coverage.py
+++ b/tests/services/test_finviz_coverage.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from mtdata.services import finviz as svc
+from mtdata.services.finviz import dates as finviz_dates
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +380,14 @@ class TestResolveDateRange:
         with pytest.raises(ValueError, match="Invalid date_to"):
             svc._resolve_date_range(date_from="2024-06-01", date_to="bad", default_days=7)
 
+    def test_malformed_iso_suffix_raises(self):
+        with pytest.raises(ValueError, match="Invalid date_from"):
+            svc._resolve_date_range(
+                date_from="2024-06-01T12:34:56junk",
+                date_to=None,
+                default_days=7,
+            )
+
     def test_to_before_from_raises(self):
         with pytest.raises(ValueError, match="date_to must be >= date_from"):
             svc._resolve_date_range(date_from="2024-06-15", date_to="2024-06-01", default_days=7)
@@ -396,6 +405,19 @@ class TestAlignToMondayIfWeekend:
 
     def test_iso_datetime_string(self):
         assert svc._align_to_next_monday_if_weekend("2024-06-09T12:34:56") == "2024-06-10"
+
+    def test_bad_iso_datetime_suffix_raises(self):
+        with pytest.raises(ValueError, match="Invalid date_from"):
+            svc._align_to_next_monday_if_weekend("2024-06-09T12:34:56junk")
+
+
+class TestDatesModuleIsoParsing:
+    def test_normalize_finviz_date_string_accepts_iso_datetime(self):
+        assert finviz_dates.normalize_finviz_date_string("2024-06-09T12:34:56Z") == "2024-06-09"
+
+    def test_align_to_next_monday_if_weekend_rejects_bad_iso_suffix(self):
+        with pytest.raises(ValueError, match="Invalid date_from"):
+            finviz_dates.align_to_next_monday_if_weekend("2024-06-09T12:34:56junk")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_finviz_coverage.py
+++ b/tests/services/test_finviz_coverage.py
@@ -394,6 +394,9 @@ class TestAlignToMondayIfWeekend:
     def test_weekday_unchanged(self):
         assert svc._align_to_next_monday_if_weekend("2024-06-10") == "2024-06-10"
 
+    def test_iso_datetime_string(self):
+        assert svc._align_to_next_monday_if_weekend("2024-06-09T12:34:56") == "2024-06-10"
+
 
 # ---------------------------------------------------------------------------
 # _filter_calendar_events_by_date (lines 811-819)


### PR DESCRIPTION
## Summary
- accept ISO datetime strings anywhere the Finviz economic-calendar date helpers currently expect plain ISO dates
- add helper- and API-level regressions for weekend alignment with datetime-style inputs

## Root cause
The Finviz economic-calendar path only parsed plain `YYYY-MM-DD` strings. If a caller supplied an ISO datetime like `2025-01-05T08:30:00`, the canonical API rejected it before weekend alignment, and the lower-level date utility also skipped alignment because it only called `date.fromisoformat()` on the full string.

## Implemented solution
- add a small parser in `services/finviz/api.py` that accepts plain ISO dates or ISO datetime strings and normalizes them to dates
- use that parser in both `_resolve_date_range()` and `_align_to_next_monday_if_weekend()` so the economic-calendar flow handles datetime inputs end-to-end
- mirror the same date-prefix handling in `services/finviz/dates.py` to keep the standalone helper consistent
- add regressions for direct weekend alignment and for `get_economic_calendar()` with a weekend ISO datetime input

## Trade-offs / limitations
This broadens acceptance for ISO-style datetime inputs only. It still rejects non-ISO date formats rather than trying to guess at them.

## Report
Resolves local report `code-reports/to-do/LOW_weekend-alignment-date-parsing.md`.