### PR TITLE
Expand labels branch mutations

### DIFF
--- a/src/mtdata/core/labels.py
+++ b/src/mtdata/core/labels.py
@@ -176,15 +176,27 @@ def labels_triple_barrier(
                     if hit_tp > 0 or hit_sl > 0:
                         break
                 if hit_tp < 0 and hit_sl < 0:
-                    labels.append(0); hold.append(int(horizon)); tp_times.append(None); sl_times.append(None)
+                    labels.append(0)
+                    hold.append(int(horizon))
+                    tp_times.append(None)
+                    sl_times.append(None)
                 elif hit_tp > 0 and (hit_sl < 0 or hit_tp < hit_sl):
-                    labels.append(1); hold.append(hit_tp); tp_times.append(_format_time_minimal(times[i+hit_tp])); sl_times.append(None)
+                    labels.append(1)
+                    hold.append(hit_tp)
+                    tp_times.append(_format_time_minimal(times[i + hit_tp]))
+                    sl_times.append(None)
                 # For high/low mode, both barriers can be touched in the same bar.
                 # Without tick ordering, assume the loss barrier was hit first.
                 elif hit_sl > 0 and (hit_tp < 0 or hit_sl <= hit_tp):
-                    labels.append(-1); hold.append(hit_sl); tp_times.append(None); sl_times.append(_format_time_minimal(times[i+hit_sl]))
+                    labels.append(-1)
+                    hold.append(hit_sl)
+                    tp_times.append(None)
+                    sl_times.append(_format_time_minimal(times[i + hit_sl]))
                 else:
-                    labels.append(0); hold.append(min(hit_tp, hit_sl)); tp_times.append(_format_time_minimal(times[i+hit_tp])); sl_times.append(_format_time_minimal(times[i+hit_sl]))
+                    labels.append(0)
+                    hold.append(min(hit_tp, hit_sl))
+                    tp_times.append(_format_time_minimal(times[i + hit_tp]))
+                    sl_times.append(_format_time_minimal(times[i + hit_sl]))
                 t_entry.append(_format_time_minimal(times[i]))
 
             payload: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
- split the semicolon-separated list mutations in the triple-barrier outcome branches into one statement per line
- keep the label-generation behavior unchanged

## Root cause
The labels module packed four parallel list mutations onto a single physical line in each barrier-outcome branch. That made the code harder to read, debug, and step through even though the underlying logic was straightforward.

## Implemented solution
- rewrite each outcome branch so `labels`, `hold`, `tp_times`, and `sl_times` are appended on separate lines
- leave the branching logic and appended values unchanged

## Trade-offs / limitations
This is a readability-only cleanup. It does not change labeling behavior or data shape.

## Report
Resolves local report `code-reports/to-do/LOW_complex-single-line-statements.md`.