### PR TITLE
Reuse shared finite price coercion

### DIFF
--- a/src/mtdata/core/data.py
+++ b/src/mtdata/core/data.py
@@ -20,6 +20,7 @@ from .execution_logging import run_logged_operation
 from .mt5_gateway import get_mt5_gateway
 from ..services.data_service import fetch_candles, fetch_ticks
 from ..utils.mt5 import ensure_mt5_connection_or_raise
+from ..utils.utils import _coerce_finite_float
 
 # Explicitly define what should be exported for '*' imports
 __all__ = ['data_fetch_candles', 'data_fetch_ticks', 'wait_event']
@@ -71,7 +72,7 @@ def _support_resistance_watchers(*, instrument: str) -> List[Dict[str, Any]]:
     for level in levels:
         if not isinstance(level, dict):
             continue
-        level_value = _coerce_price(level.get("value"))
+        level_value = _coerce_finite_float(level.get("value"))
         if level_value is None:
             continue
         level_type = str(level.get("type") or "").strip().lower()
@@ -149,7 +150,7 @@ def _extract_pivot_levels(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
             continue
         values = [
             numeric
-            for numeric in (_coerce_price(value) for key, value in row.items() if key != "level")
+            for numeric in (_coerce_finite_float(value) for key, value in row.items() if key != "level")
             if numeric is not None
         ]
         if not values:
@@ -161,16 +162,6 @@ def _extract_pivot_levels(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
         out.append({"label": label, "value": price})
     out.sort(key=lambda item: float(item["value"]))
     return out
-
-
-def _coerce_price(value: Any) -> Optional[float]:
-    try:
-        numeric = float(value)
-    except Exception:
-        return None
-    if numeric != numeric:
-        return None
-    return float(numeric)
 
 
 def _dedupe_wait_event_watchers(watch_for: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/tests/services/test_wait_event_use_cases.py
+++ b/tests/services/test_wait_event_use_cases.py
@@ -224,6 +224,27 @@ def test_support_resistance_watchers_use_compact_levels(monkeypatch) -> None:
     ]
 
 
+def test_support_resistance_watchers_ignore_non_finite_levels(monkeypatch) -> None:
+    monkeypatch.setattr(
+        core_data,
+        "support_resistance_levels",
+        lambda symbol, timeframe="auto", detail="compact": {
+            "success": True,
+            "levels": [
+                {"type": "support", "value": float("inf")},
+                {"type": "resistance", "value": 101.0},
+            ],
+        },
+    )
+
+    watchers = core_data._support_resistance_watchers(instrument="BTCUSD")
+
+    assert watchers == [
+        {"type": "price_touch_level", "symbol": "BTCUSD", "level": 101.0, "direction": "either"},
+        {"type": "price_break_level", "symbol": "BTCUSD", "level": 101.0, "direction": "up"},
+    ]
+
+
 def test_pivot_zone_watchers_use_adjacent_pivot_bands(monkeypatch) -> None:
     monkeypatch.setattr(
         core_data,


### PR DESCRIPTION
## Summary
- replace the local wait-event price coercion helper with the existing shared finite-float coercion utility
- add a regression proving non-finite support/resistance levels are ignored when default watchers are inferred

## Root cause
`core/data.py` reimplemented a small float coercion helper even though the repository already had a shared `_coerce_finite_float()` utility. The local copy also accepted infinity, so invalid price levels could leak into inferred wait-event watchers.

## Implemented solution
- import and reuse `mtdata.utils.utils._coerce_finite_float()` in the support/resistance and pivot-level watcher helpers
- remove the redundant local `_coerce_price()` implementation
- add a focused regression showing non-finite support/resistance levels are dropped instead of becoming watcher thresholds

## Trade-offs / limitations
This is mostly a dedupe, but it intentionally tightens validation by rejecting infinite values in the affected watcher helpers.

## Report
Resolves local report `code-reports/to-do/LOW_Duplicate_price_coercion_logic.md`.