### PR TITLE
Clarify NeuralForecast model errors

### DIFF
--- a/src/mtdata/forecast/methods/neural.py
+++ b/src/mtdata/forecast/methods/neural.py
@@ -34,14 +34,19 @@ def forecast_neural(
         raise RuntimeError(f"Failed to import neuralforecast models: {ex}")
 
     method_l = str(method).lower().strip()
-    model_class = {
+    model_map = {
         'nhits': _NF_NHITS,
         'nbeatsx': _NF_NBEATSX,
         'tft': _NF_TFT,
         'patchtst': _NF_PATCHTST,
-    }.get(method_l)
+    }
+    model_class = model_map.get(method_l)
     if model_class is None:
-        raise RuntimeError(f"Model '{method_l}' not available in installed neuralforecast version")
+        available_models = ", ".join(sorted(model_map))
+        raise RuntimeError(
+            f"Model '{method_l}' not available in installed neuralforecast version. "
+            f"Supported models: {available_models}"
+        )
 
     # Hyperparameters with defaults and safety caps
     h = int(fh)

--- a/src/mtdata/forecast/methods/neural.py
+++ b/src/mtdata/forecast/methods/neural.py
@@ -44,8 +44,8 @@ def forecast_neural(
     if model_class is None:
         available_models = ", ".join(sorted(model_map))
         raise RuntimeError(
-            f"Model '{method_l}' not available in installed neuralforecast version. "
-            f"Supported models: {available_models}"
+            f"Unsupported NeuralForecast model '{method_l}'. "
+            f"Supported mtdata neural models: {available_models}"
         )
 
     # Hyperparameters with defaults and safety caps

--- a/tests/forecast/test_neural_coverage.py
+++ b/tests/forecast/test_neural_coverage.py
@@ -123,7 +123,10 @@ class TestForecastNeural:
 
     def test_unknown_method(self):
         Y_df = pd.DataFrame({"unique_id": ["ts"], "ds": [0], "y": [100.0]})
-        with pytest.raises(RuntimeError, match="Supported models: nbeatsx, nhits, patchtst, tft"):
+        with pytest.raises(
+            RuntimeError,
+            match="Unsupported NeuralForecast model 'unknown_model'.*Supported mtdata neural models: nbeatsx, nhits, patchtst, tft",
+        ):
             forecast_neural(
                 method="unknown_model", series=np.array([100.0]),
                 fh=1, timeframe="H1", n=1, m=1, params={}, Y_df=Y_df,

--- a/tests/forecast/test_neural_coverage.py
+++ b/tests/forecast/test_neural_coverage.py
@@ -123,7 +123,7 @@ class TestForecastNeural:
 
     def test_unknown_method(self):
         Y_df = pd.DataFrame({"unique_id": ["ts"], "ds": [0], "y": [100.0]})
-        with pytest.raises(RuntimeError, match="not available"):
+        with pytest.raises(RuntimeError, match="Supported models: nbeatsx, nhits, patchtst, tft"):
             forecast_neural(
                 method="unknown_model", series=np.array([100.0]),
                 fh=1, timeframe="H1", n=1, m=1, params={}, Y_df=Y_df,


### PR DESCRIPTION
## Summary
- improve the unknown-model RuntimeError in `forecast_neural()` so it lists the supported NeuralForecast method names
- update the neural coverage test to lock the clearer message in place

## Root cause
The neural forecast method already rejected unknown model names, but the error only said the requested model was unavailable in the installed NeuralForecast version. That left users without the supported names they needed to distinguish a typo from a package-version issue.

## Implemented solution
- keep the existing model lookup structure but retain the model map in a local variable
- when the requested model is missing, raise a RuntimeError that includes the sorted supported model names
- update the unknown-model regression to assert the supported-models list appears in the message

## Trade-offs / limitations
This is a UX-only improvement. It does not add dynamic model discovery or change the supported-model set.

## Report
Resolves local report `code-reports/to-do/LOW_neuralforecast-model-validation.md`.