### PR TITLE
Harden symbol info cache TTL handling

### DIFF
--- a/src/mtdata/utils/mt5.py
+++ b/src/mtdata/utils/mt5.py
@@ -13,6 +13,7 @@ from ..bootstrap.settings import mt5_config
 logger = logging.getLogger(__name__)
 
 _SYMBOL_INFO_TTL_SECONDS = 5
+_SYMBOL_INFO_TTL_MAX_SECONDS = 3600.0
 _MT5_CONNECTION_FAILURE_MESSAGE = "Failed to connect to MetaTrader5. Ensure MT5 terminal is running."
 
 
@@ -169,15 +170,16 @@ def _cached_symbol_info(symbol: str, ttl_bucket: int):
     return mt5.symbol_info(symbol)
 
 
-def get_symbol_info_cached(symbol: str, ttl_seconds: int = _SYMBOL_INFO_TTL_SECONDS):
+def get_symbol_info_cached(symbol: str, ttl_seconds: float = _SYMBOL_INFO_TTL_SECONDS):
     """Fetch symbol info with a short-lived cache to reduce repeated MT5 calls."""
     try:
-        ttl = int(ttl_seconds)
-        if ttl <= 0:
-            return mt5.symbol_info(symbol)
-        bucket = int(time.time() / ttl)
+        ttl = float(ttl_seconds)
     except Exception:
-        bucket = int(time.time())
+        return mt5.symbol_info(symbol)
+    if not math.isfinite(ttl) or ttl <= 0.0:
+        return mt5.symbol_info(symbol)
+    ttl = min(ttl, _SYMBOL_INFO_TTL_MAX_SECONDS)
+    bucket = int(time.time() / ttl)
     return _cached_symbol_info(symbol, bucket)
 
 

--- a/src/mtdata/utils/mt5.py
+++ b/src/mtdata/utils/mt5.py
@@ -170,16 +170,23 @@ def _cached_symbol_info(symbol: str, ttl_bucket: int):
     return mt5.symbol_info(symbol)
 
 
-def get_symbol_info_cached(symbol: str, ttl_seconds: float = _SYMBOL_INFO_TTL_SECONDS):
-    """Fetch symbol info with a short-lived cache to reduce repeated MT5 calls."""
+def _symbol_info_ttl_bucket(ttl_seconds: float) -> Optional[int]:
     try:
         ttl = float(ttl_seconds)
     except Exception:
-        return mt5.symbol_info(symbol)
+        return None
     if not math.isfinite(ttl) or ttl <= 0.0:
-        return mt5.symbol_info(symbol)
+        return None
     ttl = min(ttl, _SYMBOL_INFO_TTL_MAX_SECONDS)
-    bucket = int(time.time() / ttl)
+    ttl_ns = max(int(math.ceil(ttl * 1_000_000_000.0)), 1)
+    return time.monotonic_ns() // ttl_ns
+
+
+def get_symbol_info_cached(symbol: str, ttl_seconds: float = _SYMBOL_INFO_TTL_SECONDS):
+    """Fetch symbol info with a short-lived cache to reduce repeated MT5 calls."""
+    bucket = _symbol_info_ttl_bucket(ttl_seconds)
+    if bucket is None:
+        return mt5.symbol_info(symbol)
     return _cached_symbol_info(symbol, bucket)
 
 

--- a/tests/trading/test_mt5_utils_coverage.py
+++ b/tests/trading/test_mt5_utils_coverage.py
@@ -78,6 +78,8 @@ def _make_tick(**kw):
 class TestGetSymbolInfoCached:
     def setup_method(self):
         clear_symbol_info_cache()
+        _mt5_mock.symbol_info.reset_mock()
+        _mt5_mock.symbol_info.side_effect = None
 
     def test_positive_ttl(self):
         _mt5_mock.symbol_info.return_value = MagicMock(bid=1.1)
@@ -95,10 +97,36 @@ class TestGetSymbolInfoCached:
         result = get_symbol_info_cached("EURUSD", ttl_seconds=-1)
         assert result is not None
 
-    def test_non_numeric_ttl_falls_back(self):
+    def test_non_numeric_ttl_falls_back_to_raw_no_cache(self):
         _mt5_mock.symbol_info.return_value = MagicMock(bid=1.4)
-        result = get_symbol_info_cached("EURUSD", ttl_seconds="bad")
-        assert result is not None
+        first = get_symbol_info_cached("EURUSD", ttl_seconds="bad")
+        second = get_symbol_info_cached("EURUSD", ttl_seconds="bad")
+        assert first is not None
+        assert second is not None
+        assert _mt5_mock.symbol_info.call_count == 2
+
+    def test_fractional_ttl_uses_cache_bucket(self, monkeypatch):
+        _mt5_mock.symbol_info.return_value = MagicMock(bid=1.5)
+        monkeypatch.setattr(_mt5_mod.time, "time", lambda: 10.0)
+
+        first = get_symbol_info_cached("EURUSD", ttl_seconds=0.5)
+        second = get_symbol_info_cached("EURUSD", ttl_seconds=0.5)
+
+        assert first is second
+        assert _mt5_mock.symbol_info.call_count == 1
+
+    def test_large_ttl_is_capped_to_short_lived_window(self, monkeypatch):
+        current_time = {"value": 10_000.0}
+        _mt5_mock.symbol_info.return_value = MagicMock(bid=1.6)
+        monkeypatch.setattr(_mt5_mod.time, "time", lambda: current_time["value"])
+
+        first = get_symbol_info_cached("EURUSD", ttl_seconds=10_000_000_000)
+        current_time["value"] += 4_000.0
+        second = get_symbol_info_cached("EURUSD", ttl_seconds=10_000_000_000)
+
+        assert first is not None
+        assert second is not None
+        assert _mt5_mock.symbol_info.call_count == 2
 
 
 class TestClearSymbolInfoCache:

--- a/tests/trading/test_mt5_utils_coverage.py
+++ b/tests/trading/test_mt5_utils_coverage.py
@@ -105,9 +105,18 @@ class TestGetSymbolInfoCached:
         assert second is not None
         assert _mt5_mock.symbol_info.call_count == 2
 
-    def test_fractional_ttl_uses_cache_bucket(self, monkeypatch):
+    @pytest.mark.parametrize("ttl_seconds", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_ttl_falls_back_to_raw_no_cache(self, ttl_seconds):
         _mt5_mock.symbol_info.return_value = MagicMock(bid=1.5)
-        monkeypatch.setattr(_mt5_mod.time, "time", lambda: 10.0)
+        first = get_symbol_info_cached("EURUSD", ttl_seconds=ttl_seconds)
+        second = get_symbol_info_cached("EURUSD", ttl_seconds=ttl_seconds)
+        assert first is not None
+        assert second is not None
+        assert _mt5_mock.symbol_info.call_count == 2
+
+    def test_fractional_ttl_uses_cache_bucket(self, monkeypatch):
+        _mt5_mock.symbol_info.return_value = MagicMock(bid=1.6)
+        monkeypatch.setattr(_mt5_mod.time, "monotonic_ns", lambda: 10_000_000_000)
 
         first = get_symbol_info_cached("EURUSD", ttl_seconds=0.5)
         second = get_symbol_info_cached("EURUSD", ttl_seconds=0.5)
@@ -115,13 +124,23 @@ class TestGetSymbolInfoCached:
         assert first is second
         assert _mt5_mock.symbol_info.call_count == 1
 
+    def test_tiny_positive_ttl_uses_nanosecond_bucket_without_overflow(self, monkeypatch):
+        _mt5_mock.symbol_info.return_value = MagicMock(bid=1.7)
+        monkeypatch.setattr(_mt5_mod.time, "monotonic_ns", lambda: 100)
+
+        first = get_symbol_info_cached("EURUSD", ttl_seconds=1e-300)
+        second = get_symbol_info_cached("EURUSD", ttl_seconds=1e-300)
+
+        assert first is second
+        assert _mt5_mock.symbol_info.call_count == 1
+
     def test_large_ttl_is_capped_to_short_lived_window(self, monkeypatch):
-        current_time = {"value": 10_000.0}
-        _mt5_mock.symbol_info.return_value = MagicMock(bid=1.6)
-        monkeypatch.setattr(_mt5_mod.time, "time", lambda: current_time["value"])
+        current_time = {"value": 10_000_000_000_000}
+        _mt5_mock.symbol_info.return_value = MagicMock(bid=1.8)
+        monkeypatch.setattr(_mt5_mod.time, "monotonic_ns", lambda: current_time["value"])
 
         first = get_symbol_info_cached("EURUSD", ttl_seconds=10_000_000_000)
-        current_time["value"] += 4_000.0
+        current_time["value"] += 4_000_000_000_000
         second = get_symbol_info_cached("EURUSD", ttl_seconds=10_000_000_000)
 
         assert first is not None


### PR DESCRIPTION
## Summary
- harden `get_symbol_info_cached()` so caller-supplied TTLs are handled explicitly instead of relying on `int()` truncation and exception buckets
- add regressions for invalid TTLs, fractional TTLs, and extremely large TTL values

## Root cause
`get_symbol_info_cached()` coerced `ttl_seconds` with `int()`, which silently truncated fractional values below one second to zero and pushed invalid inputs through a fallback bucket keyed on the current second. It also let arbitrarily large TTLs act as effectively permanent cache windows even though the helper is intended to be short-lived.

## Implemented solution
- parse TTLs as floats and bypass caching for invalid, non-finite, or non-positive values
- cap positive TTLs to a one-hour short-lived window before computing the cache bucket
- extend the MT5 utility coverage tests to lock the intended behavior in place

## Trade-offs / limitations
The helper now treats extremely large TTLs as at most a one-hour cache because the function is explicitly meant for short-lived symbol metadata caching. This preserves the default behavior while making unusual caller input less surprising.

## Report
Resolves local report `code-reports/to-do/LOW_symbol-cache-ttl-edge-cases.md`.