### PR TITLE
Document HMM entropy trend thresholds

### DIFF
--- a/src/mtdata/core/regime/methods/hmm/core.py
+++ b/src/mtdata/core/regime/methods/hmm/core.py
@@ -2,9 +2,21 @@
 from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
+_ENTROPY_TREND_RELATIVE_CHANGE = 0.15
+_ENTROPY_TREND_IMPROVING_MULTIPLIER = 1.0 - _ENTROPY_TREND_RELATIVE_CHANGE
+_ENTROPY_TREND_DEGRADING_MULTIPLIER = 1.0 + _ENTROPY_TREND_RELATIVE_CHANGE
+
 
 def _hmm_reliability_from_gamma(gamma: np.ndarray, states: np.ndarray) -> Dict[str, Any]:
-    """Estimate HMM reliability from marginal probabilities."""
+    """Estimate HMM reliability from marginal probabilities.
+
+    ``entropy_trend`` compares the mean entropy in the second half of the
+    series against the first half. Smaller relative moves stay ``"stable"`` so
+    minor noise does not flip the trend label; a materially lower second-half
+    entropy means the HMM is becoming more certain (``"improving"``), while a
+    materially higher second-half entropy means the fit is becoming less
+    certain (``"degrading"``).
+    """
     n = int(gamma.shape[0])
     k = int(gamma.shape[1])
     if n == 0 or k == 0:
@@ -19,9 +31,9 @@ def _hmm_reliability_from_gamma(gamma: np.ndarray, states: np.ndarray) -> Dict[s
     second_half = entropies[n // 2 :] if n > 1 else entropies
     trend = "stable"
     if first_half.size and second_half.size:
-        if np.mean(second_half) < np.mean(first_half) * 0.85:
+        if np.mean(second_half) < np.mean(first_half) * _ENTROPY_TREND_IMPROVING_MULTIPLIER:
             trend = "improving"
-        elif np.mean(second_half) > np.mean(first_half) * 1.15:
+        elif np.mean(second_half) > np.mean(first_half) * _ENTROPY_TREND_DEGRADING_MULTIPLIER:
             trend = "degrading"
 
     return {"confidence": round(reliability, 4), "entropy_trend": trend}


### PR DESCRIPTION
## Summary
- name the HMM entropy-trend multipliers instead of leaving the `0.85` / `1.15` thresholds inline
- expand the helper docstring so the trend labels explain how the second-half entropy is interpreted

## Root cause
The HMM reliability helper already used a simple 15% relative-change heuristic, but the thresholds were embedded as unexplained literals. That made the trend semantics hard to understand and disconnected the implementation from the rationale that the report called out.

## Implemented solution
- extract the relative-change threshold and derived multipliers into descriptive module-level constants
- document that small entropy moves stay `stable`, lower second-half entropy means improving certainty, and higher second-half entropy means degrading certainty
- keep the existing behavior unchanged

## Trade-offs / limitations
This documents the current heuristic but does not make it configurable or statistically calibrated. The change is intentionally limited to clarity and maintainability.

## Report
Resolves local report `code-reports/to-do/LOW_hmm-undocumented-thresholds.md`.