### PR TITLE
trading: add EWMA and Cornish-Fisher VaR methods

### DIFF
--- a/src/mtdata/core/trading/requests.py
+++ b/src/mtdata/core/trading/requests.py
@@ -281,7 +281,12 @@ class TradeVarCvarRequest(BaseModel):
             "or a percentage such as 95. Values must resolve to 0 < confidence < 1."
         ),
     )
-    method: str = "historical"
+    method: str = Field(
+        default="historical",
+        description=(
+            "Tail-risk method. Use historical, gaussian, cornish_fisher, or ewma."
+        ),
+    )
     transform: str = "log_return"
     min_observations: int = 50
     detail: CompactFullDetailLiteral = Field(

--- a/src/mtdata/core/trading/use_cases.py
+++ b/src/mtdata/core/trading/use_cases.py
@@ -9,6 +9,8 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+import numpy as np
+
 from ...bootstrap.settings import trade_guardrails_config
 from ...shared.constants import TIMEFRAME_MAP
 from ...shared.result import Err, Ok, Result, to_dict
@@ -565,7 +567,13 @@ def _normalize_var_cvar_method(method: Any) -> tuple[Optional[str], Optional[str
         return "historical", None
     if method_text in {"gaussian", "normal", "parametric"}:
         return "gaussian", None
-    return None, "Invalid method. Valid options: historical, gaussian"
+    if method_text in {"cornish_fisher", "cornish-fisher", "cf"}:
+        return "cornish_fisher", None
+    if method_text in {"ewma", "ewma_historical"}:
+        return "ewma", None
+    return None, (
+        "Invalid method. Valid options: historical, gaussian, cornish_fisher, ewma"
+    )
 
 
 def _normalize_var_cvar_transform(
@@ -653,6 +661,83 @@ def _gaussian_var_cvar_tail(
     return var_value, cvar_value, threshold
 
 
+def _cornish_fisher_var_cvar_tail(
+    pnl_values: List[float], confidence: float
+) -> tuple[float, float, float]:
+    from scipy.stats import norm
+
+    ordered = np.asarray([float(value) for value in pnl_values], dtype=float)
+    if ordered.size == 0:
+        return 0.0, 0.0, 0.0
+    if ordered.size < 3:
+        return _gaussian_var_cvar_tail(pnl_values, confidence)
+
+    mean_pnl = float(np.mean(ordered))
+    centered = ordered - mean_pnl
+    std_pnl = float(np.std(ordered, ddof=1))
+    if not math.isfinite(std_pnl) or std_pnl <= 0.0:
+        threshold = mean_pnl
+        var_value = max(0.0, -threshold)
+        return var_value, var_value, threshold
+
+    z_score = float(norm.ppf(1.0 - confidence))
+    standardized = centered / std_pnl
+    skewness = float(np.mean(standardized ** 3))
+    excess_kurtosis = float(np.mean(standardized ** 4) - 3.0)
+    z_cf = (
+        z_score
+        + ((z_score**2 - 1.0) * skewness / 6.0)
+        + ((z_score**3 - (3.0 * z_score)) * excess_kurtosis / 24.0)
+        - (((2.0 * (z_score**3)) - (5.0 * z_score)) * (skewness**2) / 36.0)
+    )
+    threshold = mean_pnl + (std_pnl * z_cf)
+
+    tail_values = ordered[ordered <= threshold]
+    tail_mean = float(np.mean(tail_values)) if tail_values.size else float(threshold)
+    var_value = max(0.0, -float(threshold))
+    cvar_value = max(0.0, -tail_mean)
+    return var_value, cvar_value, float(threshold)
+
+
+def _ewma_var_cvar_tail(
+    pnl_values: List[float], confidence: float, *, decay: float = 0.94
+) -> tuple[float, float, float]:
+    ordered = np.asarray([float(value) for value in pnl_values], dtype=float)
+    if ordered.size == 0:
+        return 0.0, 0.0, 0.0
+    if ordered.size == 1:
+        threshold = float(ordered[0])
+        var_value = max(0.0, -threshold)
+        return var_value, var_value, threshold
+
+    lam = min(max(float(decay), 0.0), 0.999999)
+    ages = np.arange(ordered.size - 1, -1, -1, dtype=float)
+    weights = (1.0 - lam) * np.power(lam, ages)
+    total_weight = float(np.sum(weights))
+    if not math.isfinite(total_weight) or total_weight <= 0.0:
+        return _historical_var_cvar_tail(pnl_values, confidence)
+    weights = weights / total_weight
+
+    sort_idx = np.argsort(ordered)
+    sorted_pnl = ordered[sort_idx]
+    sorted_weights = weights[sort_idx]
+    alpha = 1.0 - confidence
+    cumulative = np.cumsum(sorted_weights)
+    threshold_idx = int(np.searchsorted(cumulative, alpha, side="left"))
+    threshold_idx = max(0, min(threshold_idx, sorted_pnl.size - 1))
+    threshold = float(sorted_pnl[threshold_idx])
+    tail_mask = sorted_pnl <= threshold
+    tail_weights = sorted_weights[tail_mask]
+    tail_total = float(np.sum(tail_weights))
+    if tail_total <= 0.0:
+        tail_mean = threshold
+    else:
+        tail_mean = float(np.dot(sorted_pnl[tail_mask], tail_weights) / tail_total)
+    var_value = max(0.0, -threshold)
+    cvar_value = max(0.0, -tail_mean)
+    return var_value, cvar_value, threshold
+
+
 def _calculate_var_cvar_from_pnl(
     pnl_values: List[float],
     *,
@@ -661,7 +746,13 @@ def _calculate_var_cvar_from_pnl(
 ) -> tuple[float, float, float]:
     if method == "historical":
         return _historical_var_cvar_tail(pnl_values, confidence)
-    return _gaussian_var_cvar_tail(pnl_values, confidence)
+    if method == "gaussian":
+        return _gaussian_var_cvar_tail(pnl_values, confidence)
+    if method == "cornish_fisher":
+        return _cornish_fisher_var_cvar_tail(pnl_values, confidence)
+    if method == "ewma":
+        return _ewma_var_cvar_tail(pnl_values, confidence)
+    raise ValueError(f"Unsupported VaR/CVaR method: {method}")
 
 
 def _extract_var_cvar_return_series(

--- a/tests/trading/test_trading_var_cvar_business_logic.py
+++ b/tests/trading/test_trading_var_cvar_business_logic.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from mtdata.core.trading.requests import TradeVarCvarRequest
 from mtdata.core.trading.use_cases import (
+    _normalize_var_cvar_method,
     _calculate_var_cvar_from_pnl,
     run_trade_var_cvar_calculate,
 )
@@ -31,6 +32,44 @@ def test_calculate_var_cvar_from_pnl_gaussian_cvar_exceeds_var() -> None:
     assert threshold < 0.0
     assert var_value > 0.0
     assert cvar_value >= var_value
+
+
+def test_normalize_var_cvar_method_accepts_cornish_fisher_and_ewma() -> None:
+    assert _normalize_var_cvar_method("cornish-fisher") == ("cornish_fisher", None)
+    assert _normalize_var_cvar_method("ewma") == ("ewma", None)
+
+
+def test_calculate_var_cvar_from_pnl_cornish_fisher_cvar_exceeds_var() -> None:
+    var_value, cvar_value, threshold = _calculate_var_cvar_from_pnl(
+        [18.0, -25.0, 7.0, -11.0, 9.0, -4.0, 3.0, -30.0, 16.0],
+        confidence=0.95,
+        method="cornish_fisher",
+    )
+
+    assert threshold < 0.0
+    assert var_value > 0.0
+    assert cvar_value >= var_value
+
+
+def test_calculate_var_cvar_from_pnl_ewma_emphasizes_recent_losses() -> None:
+    pnl_values = [0.0] * 49 + [-10.0]
+
+    historical_var, _, historical_threshold = _calculate_var_cvar_from_pnl(
+        pnl_values,
+        confidence=0.95,
+        method="historical",
+    )
+    ewma_var, ewma_cvar, ewma_threshold = _calculate_var_cvar_from_pnl(
+        pnl_values,
+        confidence=0.95,
+        method="ewma",
+    )
+
+    assert historical_threshold == 0.0
+    assert historical_var == 0.0
+    assert ewma_threshold == -10.0
+    assert ewma_var == 10.0
+    assert ewma_cvar == 10.0
 
 
 def test_run_trade_var_cvar_calculate_summarizes_open_position_portfolio() -> None:


### PR DESCRIPTION
## Summary
- add cornish_fisher and wma as supported VaR/CVaR calculation methods
- keep the existing historical and gaussian paths unchanged
- extend targeted business-logic tests for the new normalization and tail estimators

## Validation
- python -m pytest tests/trading/test_trading_var_cvar_business_logic.py -q