### PR TITLE
forecast: prefer OptimizedTheta for theta

### DIFF
--- a/src/mtdata/forecast/methods/classical.py
+++ b/src/mtdata/forecast/methods/classical.py
@@ -123,6 +123,18 @@ class ThetaMethod(ClassicalMethod):
         exog_future: Optional[pd.DataFrame] = None,
         **kwargs
     ) -> ForecastResult:
+        if params.get("alpha") is None:
+            sf_result = self._forecast_with_statsforecast(
+                series=series,
+                horizon=horizon,
+                seasonality=seasonality,
+                params=params,
+                exog_future=exog_future,
+                **kwargs,
+            )
+            if sf_result is not None:
+                return sf_result
+
         vals = np.asarray(series.values, dtype=float)
         n = int(vals.size)
         if n == 0:
@@ -146,6 +158,45 @@ class ThetaMethod(ClassicalMethod):
         
         f_vals = 0.5 * (trend_future + ses_future)
         return ForecastResult(forecast=f_vals, params_used={"alpha": alpha, "trend_slope": b})
+
+    def _forecast_with_statsforecast(
+        self,
+        *,
+        series: pd.Series,
+        horizon: int,
+        seasonality: int,
+        params: Dict[str, Any],
+        exog_future: Optional[pd.DataFrame] = None,
+        **kwargs: Any,
+    ) -> Optional[ForecastResult]:
+        try:
+            from .statsforecast import GenericStatsForecastMethod
+        except Exception:
+            return None
+
+        sf_params = dict(params or {})
+        sf_params["model_name"] = "OptimizedTheta"
+        try:
+            result = GenericStatsForecastMethod().forecast(
+                series,
+                horizon,
+                seasonality,
+                sf_params,
+                exog_future=exog_future,
+                **kwargs,
+            )
+        except Exception:
+            return None
+
+        params_used = dict(result.params_used or {})
+        params_used["model_name"] = "OptimizedTheta"
+        params_used["backend"] = "statsforecast"
+        return ForecastResult(
+            forecast=np.asarray(result.forecast, dtype=float),
+            ci_values=result.ci_values,
+            params_used=params_used,
+            metadata=result.metadata,
+        )
 
 @ForecastRegistry.register("fourier_ols")
 class FourierOLSMethod(ClassicalMethod):
@@ -210,4 +261,3 @@ class FourierOLSMethod(ClassicalMethod):
             forecast=f_vals.astype(float, copy=False), 
             params_used={"m": m_eff, "K": K_eff, "trend": bool(trend)}
         )
-

--- a/tests/forecast/test_classical_method_business_logic.py
+++ b/tests/forecast/test_classical_method_business_logic.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from mtdata.forecast.methods import classical as cl
+from mtdata.forecast.interface import ForecastResult
 
 
 def test_classical_base_metadata_via_naive_method():
@@ -75,6 +76,52 @@ def test_theta_forecast_rejects_non_finite_series_values():
 
     with pytest.raises(ValueError, match="finite"):
         method.forecast(pd.Series([2.0, np.nan, 6.0]), horizon=2, seasonality=0, params={})
+
+
+def test_theta_forecast_prefers_statsforecast_default_path(monkeypatch):
+    def _fake_forecast(self, series, horizon, seasonality, params, exog_future=None, **kwargs):
+        assert params["model_name"] == "OptimizedTheta"
+        return ForecastResult(
+            forecast=np.array([10.0, 11.0]),
+            params_used={"seasonality": seasonality},
+        )
+
+    monkeypatch.setattr(
+        "mtdata.forecast.methods.statsforecast.GenericStatsForecastMethod.forecast",
+        _fake_forecast,
+    )
+
+    out = cl.ThetaMethod().forecast(
+        pd.Series([2.0, 4.0, 6.0, 8.0]),
+        horizon=2,
+        seasonality=0,
+        params={},
+    )
+
+    assert np.allclose(out.forecast, [10.0, 11.0])
+    assert out.params_used["model_name"] == "OptimizedTheta"
+    assert out.params_used["backend"] == "statsforecast"
+
+
+def test_theta_forecast_falls_back_to_legacy_when_statsforecast_path_fails(monkeypatch):
+    def _fail_forecast(self, series, horizon, seasonality, params, exog_future=None, **kwargs):
+        raise RuntimeError("statsforecast unavailable")
+
+    monkeypatch.setattr(
+        "mtdata.forecast.methods.statsforecast.GenericStatsForecastMethod.forecast",
+        _fail_forecast,
+    )
+
+    out = cl.ThetaMethod().forecast(
+        pd.Series([2.0, 4.0, 6.0, 8.0]),
+        horizon=2,
+        seasonality=0,
+        params={},
+    )
+
+    assert out.params_used is not None
+    assert out.params_used["alpha"] == 0.2
+    assert out.params_used["trend_slope"] == pytest.approx(2.0, abs=1e-10)
 
 
 def test_fourier_ols_default_and_custom_params():


### PR DESCRIPTION
## Summary
- route the default 	heta path through StatsForecast OptimizedTheta when available
- keep the legacy alpha-driven implementation as an explicit fallback
- add focused tests for the preferred backend and fallback behavior

## Validation
- python -m pytest tests/forecast/test_classical_method_business_logic.py -q