### PR TITLE
forecast: prefer AutoARIMA by default

### DIFF
--- a/src/mtdata/forecast/methods/ets_arima.py
+++ b/src/mtdata/forecast/methods/ets_arima.py
@@ -383,7 +383,65 @@ class ARIMAMethod(ETSArimaMethod):
         exog_future: Optional[pd.DataFrame] = None,
         **kwargs
     ) -> ForecastResult:
+        if self._should_use_auto_arima(params):
+            auto_result = self._forecast_with_auto_arima(
+                series=series,
+                horizon=horizon,
+                seasonality=seasonality,
+                params=params,
+                exog_future=exog_future,
+                **kwargs,
+            )
+            if auto_result is not None:
+                return auto_result
         return self._forecast_sarimax(series, horizon, seasonality, params, seasonal=False, exog_future=exog_future, **kwargs)
+
+    @staticmethod
+    def _should_use_auto_arima(params: Dict[str, Any]) -> bool:
+        manual_keys = {"order", "p", "d", "q"}
+        return not any(params.get(key) is not None for key in manual_keys)
+
+    def _forecast_with_auto_arima(
+        self,
+        *,
+        series: pd.Series,
+        horizon: int,
+        seasonality: int,
+        params: Dict[str, Any],
+        exog_future: Optional[pd.DataFrame] = None,
+        **kwargs: Any,
+    ) -> Optional[ForecastResult]:
+        try:
+            from .statsforecast import GenericStatsForecastMethod
+        except Exception:
+            return None
+
+        sf_params = dict(params or {})
+        sf_params["model_name"] = "AutoARIMA"
+        if int(seasonality or 0) > 1:
+            sf_params.setdefault("season_length", int(seasonality))
+        try:
+            result = GenericStatsForecastMethod().forecast(
+                series,
+                horizon,
+                seasonality,
+                sf_params,
+                exog_future=exog_future,
+                **kwargs,
+            )
+        except Exception:
+            return None
+
+        params_used = dict(result.params_used or {})
+        params_used["model_name"] = "AutoARIMA"
+        params_used["backend"] = "statsforecast"
+        params_used["auto_selected"] = True
+        return ForecastResult(
+            forecast=np.asarray(result.forecast, dtype=float),
+            ci_values=result.ci_values,
+            params_used=params_used,
+            metadata=result.metadata,
+        )
 
     def _forecast_sarimax(self, series, horizon, seasonality, params, seasonal, exog_future=None, **kwargs):
         if not _SM_SARIMAX_AVAILABLE:
@@ -522,6 +580,5 @@ class SARIMAMethod(ARIMAMethod):
         **kwargs
     ) -> ForecastResult:
         return self._forecast_sarimax(series, horizon, seasonality, params, seasonal=True, exog_future=exog_future, **kwargs)
-
 
 

--- a/tests/forecast/test_ets_arima_business_logic.py
+++ b/tests/forecast/test_ets_arima_business_logic.py
@@ -285,7 +285,38 @@ def test_ets_forecast_rejects_insufficient_history_for_seasonal_fit(monkeypatch)
 def test_arima_requires_statsmodels(monkeypatch):
     monkeypatch.setattr(ea, "_SM_SARIMAX_AVAILABLE", False)
     with pytest.raises(RuntimeError, match="requires statsmodels"):
-        ea.ARIMAMethod().forecast(pd.Series([1.0, 2.0]), horizon=1, seasonality=0, params={})
+        ea.ARIMAMethod().forecast(
+            pd.Series([1.0, 2.0]),
+            horizon=1,
+            seasonality=0,
+            params={"p": 1, "d": 1, "q": 1},
+        )
+
+
+def test_arima_prefers_auto_arima_when_no_order_supplied(monkeypatch):
+    def _fake_forecast(self, series, horizon, seasonality, params, exog_future=None, **kwargs):
+        assert params["model_name"] == "AutoARIMA"
+        return ForecastResult(
+            forecast=np.array([21.0, 22.0], dtype=float),
+            params_used={"seasonality": seasonality},
+        )
+
+    monkeypatch.setattr(
+        "mtdata.forecast.methods.statsforecast.GenericStatsForecastMethod.forecast",
+        _fake_forecast,
+    )
+
+    out = ea.ARIMAMethod().forecast(
+        pd.Series([10.0, 11.0, 12.0]),
+        horizon=2,
+        seasonality=0,
+        params={},
+    )
+
+    assert np.allclose(out.forecast, [21.0, 22.0])
+    assert out.params_used["model_name"] == "AutoARIMA"
+    assert out.params_used["backend"] == "statsforecast"
+    assert out.params_used["auto_selected"] is True
 
 
 def test_arima_builds_orders_ci_and_exog_metadata(monkeypatch):
@@ -405,6 +436,10 @@ def test_arima_conf_int_errors_are_reported_in_metadata(monkeypatch):
 
     monkeypatch.setattr(ea, "_SM_SARIMAX_AVAILABLE", True)
     monkeypatch.setattr(ea, "_SARIMAX", FakeSarimax)
+    monkeypatch.setattr(
+        "mtdata.forecast.methods.statsforecast.GenericStatsForecastMethod.forecast",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("auto unavailable")),
+    )
 
     out = ea.ARIMAMethod().forecast(pd.Series([1.0, 2.0, 3.0]), horizon=1, seasonality=0, params={})
     assert np.allclose(out.forecast, [3.0])


### PR DESCRIPTION
## Summary
- route the default rima path through StatsForecast AutoARIMA when no explicit order is supplied
- preserve explicit-order SARIMAX behavior and safe fallback when the auto path is unavailable
- add focused tests for the preferred auto path and the legacy fallback

## Validation
- python -m pytest tests/forecast/test_ets_arima_business_logic.py -q