### PR TITLE
forecast: interpolate pretrained NaN gaps

### DIFF
--- a/src/mtdata/forecast/methods/pretrained_helpers.py
+++ b/src/mtdata/forecast/methods/pretrained_helpers.py
@@ -45,7 +45,7 @@ def validate_and_clean_data(
     method_name: str = "forecast"
 ) -> Tuple[np.ndarray, Optional[str]]:
     """
-    Validate and clean time series data by handling NaN values.
+    Validate and clean time series data by interpolating missing values.
     
     Args:
         data: Input time series data
@@ -62,12 +62,15 @@ def validate_and_clean_data(
     if not np.any(np.isfinite(data)):
         return np.array([]), f"{method_name} error: context contains no finite values"
     
-    # Clean the data - replace NaN with mean of finite values
-    finite_mean = np.nanmean(data[np.isfinite(data)])
-    if not np.isfinite(finite_mean):
-        finite_mean = 0.0
-    
-    cleaned_data = np.nan_to_num(data, nan=float(finite_mean))
+    cleaned_data = np.asarray(data, dtype=float).copy()
+    finite_mask = np.isfinite(cleaned_data)
+    if not finite_mask.all():
+        idx = np.arange(cleaned_data.size, dtype=float)
+        cleaned_data[~finite_mask] = np.interp(
+            idx[~finite_mask],
+            idx[finite_mask],
+            cleaned_data[finite_mask],
+        )
     
     # Validate cleaned data
     if not np.any(np.isfinite(cleaned_data)):
@@ -227,5 +230,4 @@ def safe_import_modules(
         return None, f"{method_name} requires {', '.join(required_modules)}: {ex}"
     
     return imported_modules, None
-
 

--- a/tests/forecast/test_pretrained_helpers.py
+++ b/tests/forecast/test_pretrained_helpers.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from mtdata.forecast.methods.pretrained_helpers import validate_and_clean_data
+
+
+def test_validate_and_clean_data_interpolates_internal_gaps():
+    cleaned, error = validate_and_clean_data(np.array([1.0, np.nan, np.nan, 4.0]))
+
+    assert error is None
+    np.testing.assert_allclose(cleaned, np.array([1.0, 2.0, 3.0, 4.0]))
+
+
+def test_validate_and_clean_data_edge_fills_missing_values():
+    cleaned, error = validate_and_clean_data(np.array([np.nan, 2.0, np.nan, 6.0, np.nan]))
+
+    assert error is None
+    np.testing.assert_allclose(cleaned, np.array([2.0, 2.0, 4.0, 6.0, 6.0]))


### PR DESCRIPTION
## Summary
- replace mean imputation in validate_and_clean_data with linear interpolation over finite points
- edge-fill leading and trailing gaps with the nearest observed value to keep contexts time-series-friendly
- add focused helper tests for interpolation and edge-fill behavior

## Validation
- python -m ruff check src\\mtdata\\forecast\\methods\\pretrained_helpers.py tests\\forecast\\test_pretrained_helpers.py
- python -m pytest tests\\forecast\\test_pretrained_helpers.py tests\\forecast\\test_dry_optimization.py