### PR TITLE
forecast: use default_rng in mc_gbm return sims

### DIFF
--- a/src/mtdata/forecast/methods/monte_carlo.py
+++ b/src/mtdata/forecast/methods/monte_carlo.py
@@ -4,9 +4,9 @@ import numpy as np
 import pandas as pd
 
 from ..common import log_returns_from_prices as _log_returns_from_prices
+from ..forecast_registry import ForecastRegistry
 from ..interface import ForecastMethod, ForecastResult
 from ..monte_carlo import simulate_gbm_mc, simulate_hmm_mc
-from ..forecast_registry import ForecastRegistry
 
 
 def _ci_from_sims(paths: np.ndarray, alpha: float) -> Tuple[np.ndarray, np.ndarray]:
@@ -121,7 +121,7 @@ class MonteCarloGBMMethod(ForecastMethod):
         rets = x
         mu = float(params.get("mu", float(np.mean(rets))))
         sigma = float(params.get("sigma", float(np.std(rets, ddof=1) + 1e-12)))
-        rng = np.random.RandomState(seed)
+        rng = np.random.default_rng(seed)
         ret_paths = rng.normal(loc=mu, scale=max(sigma, 1e-12), size=(n_sims, fh))
         point = np.median(ret_paths, axis=0)
         ci = None

--- a/tests/forecast/test_monte_carlo_simulation_coherence.py
+++ b/tests/forecast/test_monte_carlo_simulation_coherence.py
@@ -12,13 +12,13 @@ import pandas as pd
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
 import mtdata.forecast.methods.monte_carlo  # noqa: F401
+from mtdata.forecast.forecast_registry import ForecastRegistry
 from mtdata.forecast.monte_carlo import (
     estimate_transition_matrix_from_gamma,
     simulate_garch_mc,
     simulate_gbm_mc,
     simulate_markov_chain,
 )
-from mtdata.forecast.forecast_registry import ForecastRegistry
 
 
 class TestMonteCarloSimulationCoherence(unittest.TestCase):
@@ -66,6 +66,59 @@ class TestMonteCarloSimulationCoherence(unittest.TestCase):
         expected_sigma = float(np.std(rets, ddof=1) + 1e-12)
         self.assertEqual(result.params_used["target"], "return")
         self.assertAlmostEqual(result.params_used["sigma"], expected_sigma)
+
+    def test_monte_carlo_registry_return_target_uses_default_rng(self) -> None:
+        rets = np.array([0.01, 0.04, -0.02, 0.03, 0.00, 0.02], dtype=float)
+        method = ForecastRegistry.get("mc_gbm")
+        captured = {}
+
+        class FakeGenerator:
+            def normal(self, loc: float, scale: float, size: tuple[int, int]) -> np.ndarray:
+                captured["loc"] = loc
+                captured["scale"] = scale
+                captured["size"] = size
+                return np.full(size, loc, dtype=float)
+
+        def fake_default_rng(seed: int) -> FakeGenerator:
+            captured["seed"] = seed
+            return FakeGenerator()
+
+        with patch("mtdata.forecast.methods.monte_carlo.np.random.default_rng", side_effect=fake_default_rng):
+            result = method.forecast(
+                series=pd.Series(rets),
+                horizon=4,
+                seasonality=1,
+                params={"n_sims": 7, "seed": 11, "quantity": "return"},
+            )
+
+        self.assertEqual(captured["seed"], 11)
+        self.assertEqual(captured["size"], (7, 4))
+        self.assertTrue(np.allclose(result.forecast, np.full(4, captured["loc"], dtype=float)))
+
+    def test_monte_carlo_registry_return_target_is_reproducible_with_seed(self) -> None:
+        rets = np.array([0.01, 0.04, -0.02, 0.03, 0.00, 0.02], dtype=float)
+        method = ForecastRegistry.get("mc_gbm")
+
+        first = method.forecast(
+            series=pd.Series(rets),
+            horizon=5,
+            seasonality=1,
+            params={"n_sims": 50, "seed": 17, "quantity": "return", "ci_alpha": 0.1},
+        )
+        second = method.forecast(
+            series=pd.Series(rets),
+            horizon=5,
+            seasonality=1,
+            params={"n_sims": 50, "seed": 17, "quantity": "return", "ci_alpha": 0.1},
+        )
+
+        self.assertTrue(np.allclose(first.forecast, second.forecast))
+        self.assertIsNotNone(first.ci_values)
+        self.assertIsNotNone(second.ci_values)
+        assert first.ci_values is not None
+        assert second.ci_values is not None
+        self.assertTrue(np.allclose(first.ci_values[0], second.ci_values[0]))
+        self.assertTrue(np.allclose(first.ci_values[1], second.ci_values[1]))
 
     def test_monte_carlo_registry_method_routes_overrides_through_shared_simulator(self) -> None:
         series = np.linspace(100.0, 120.0, 200)


### PR DESCRIPTION
## Summary
- switch MonteCarloGBMMethod return-target sampling from RandomState to default_rng
- preserve deterministic behavior by continuing to seed from the method params
- add focused tests for the default_rng call path and reproducibility under the same seed

## Validation
- python -m ruff check src\\mtdata\\forecast\\methods\\monte_carlo.py tests\\forecast\\test_monte_carlo_simulation_coherence.py
- python -m pytest tests\\forecast\\test_monte_carlo_simulation_coherence.py