### PR TITLE
utils: use finest detail for wavelet packet sigma

### DIFF
--- a/src/mtdata/utils/denoise/filters/wavelet.py
+++ b/src/mtdata/utils/denoise/filters/wavelet.py
@@ -12,6 +12,32 @@ except Exception:
 from ..base import _series_like, register_filter
 
 
+def _estimate_wavelet_packet_sigma(
+    wp: Any,
+    nodes: list[Any],
+    x: np.ndarray,
+) -> float:
+    coeffs = np.array([], dtype=float)
+    try:
+        coeffs = np.asarray(wp["d"].data, dtype=float).ravel()
+    except Exception:
+        coeffs = np.array([], dtype=float)
+
+    coeffs = coeffs[np.isfinite(coeffs)]
+    if coeffs.size:
+        return float(np.median(np.abs(coeffs)) / 0.6745)
+
+    try:
+        coeffs = np.asarray(nodes[-1].data, dtype=float).ravel()
+    except Exception:
+        coeffs = np.array([], dtype=float)
+
+    coeffs = coeffs[np.isfinite(coeffs)]
+    if coeffs.size:
+        return float(np.median(np.abs(coeffs)) / 0.6745)
+    return float(np.std(x))
+
+
 def _wavelet_packet_denoise(
     x: np.ndarray,
     wavelet: str,
@@ -38,8 +64,7 @@ def _wavelet_packet_denoise(
     nodes = wp.get_level(level_val, order="freq")
     if not nodes:
         return x
-    coeffs = np.concatenate([node.data.ravel() for node in nodes])
-    sigma = np.median(np.abs(coeffs)) / 0.6745 if coeffs.size else float(np.std(x))
+    sigma = _estimate_wavelet_packet_sigma(wp, nodes, x)
     thr = threshold
     if threshold_scale == "auto":
         denom = float(np.std(x)) + 1e-12

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -1,11 +1,12 @@
 """Comprehensive tests for mtdata.utils.denoise module."""
 
+import math
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
 
-from mtdata.utils.denoise import api as denoise_api
-from mtdata.utils.denoise.api import _run_denoise_handler
 from mtdata.utils.denoise import (
     _apply_denoise,
     _denoise_series,
@@ -14,12 +15,15 @@ from mtdata.utils.denoise import (
     get_denoise_methods_data,
     normalize_denoise_spec,
 )
+from mtdata.utils.denoise import api as denoise_api
+from mtdata.utils.denoise.api import _run_denoise_handler
+from mtdata.utils.denoise.filters import specialized as specialized_filters
+from mtdata.utils.denoise.filters import wavelet as wavelet_mod
 from mtdata.utils.denoise.filters.adaptive import (
     _adaptive_lms_filter,
     _adaptive_rls_filter,
 )
 from mtdata.utils.denoise.filters.decomposition import _ssa_denoise, _vmd_denoise
-from mtdata.utils.denoise.filters import specialized as specialized_filters
 from mtdata.utils.denoise.filters.specialized import (
     _bilateral_filter_1d,
     _hampel_filter,
@@ -999,6 +1003,57 @@ class TestWaveletPacketDenoise:
         y = _wavelet_packet_denoise(NOISY_SIGNAL, wavelet="INVALID_WAVELET", level=2,
                                     threshold="auto", mode="soft")
         np.testing.assert_array_equal(y, NOISY_SIGNAL)
+
+    def test_auto_threshold_uses_finest_detail_coefficients(self, monkeypatch):
+        class FakeNode:
+            def __init__(self, data):
+                self.data = np.asarray(data, dtype=float)
+
+        terminal_nodes = [FakeNode([40.0, 45.0]), FakeNode([60.0, 65.0])]
+        finest_detail = FakeNode([0.0, 1.0, -1.0, 0.5])
+        thresholds = []
+
+        class FakeWaveletPacket:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def get_level(self, level, order="freq"):
+                return terminal_nodes
+
+            def __getitem__(self, key):
+                if key == "d":
+                    return finest_detail
+                raise KeyError(key)
+
+            def reconstruct(self, update=False):
+                return NOISY_SIGNAL.copy()
+
+        fake_pywt = SimpleNamespace(
+            Wavelet=lambda wavelet: SimpleNamespace(dec_len=2),
+            dwt_max_level=lambda n, dec_len: 2,
+            WaveletPacket=FakeWaveletPacket,
+            threshold=lambda data, thr, mode: thresholds.append(thr) or np.asarray(data, dtype=float),
+        )
+        monkeypatch.setattr(wavelet_mod, "_pywt", fake_pywt)
+
+        y = _wavelet_packet_denoise(
+            NOISY_SIGNAL,
+            wavelet="db4",
+            level=2,
+            threshold="auto",
+            mode="soft",
+            threshold_scale=None,
+        )
+
+        expected_sigma = np.median(np.abs(finest_detail.data)) / 0.6745
+        expected_thr = float(expected_sigma * math.sqrt(2.0 * math.log(len(NOISY_SIGNAL))))
+        all_terminal_sigma = np.median(np.abs(np.concatenate([node.data for node in terminal_nodes]))) / 0.6745
+        all_terminal_thr = float(all_terminal_sigma * math.sqrt(2.0 * math.log(len(NOISY_SIGNAL))))
+
+        _check_basic(y, N)
+        assert thresholds
+        assert thresholds[0] == pytest.approx(expected_thr)
+        assert thresholds[0] != pytest.approx(all_terminal_thr)
 
 
 class TestVmdDenoise:


### PR DESCRIPTION
## Summary
- estimate wavelet-packet noise sigma from the finest detail coefficients (wp['d']) instead of all terminal leaves
- keep a safe fallback to the highest-frequency terminal node or the raw series standard deviation when detail coefficients are unavailable
- add focused tests that pin the automatic threshold calculation to the finest-detail coefficients

## Validation
- python -m ruff check src\\mtdata\\utils\\denoise\\filters\\wavelet.py tests\\utils\\test_denoise_pure.py
- python -m pytest tests\\utils\\test_denoise.py::test_denoise_series_wavelet_packet tests\\utils\\test_denoise_pure.py::TestWaveletPacketDenoise