### PR TITLE
utils: use tslearn fast path for DTW fallback

### DIFF
--- a/src/mtdata/utils/dtw.py
+++ b/src/mtdata/utils/dtw.py
@@ -1,32 +1,27 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from math import sqrt
 from typing import Optional
 
 import numpy as np
 
 
-def dtw_distance_fallback(
-    a: np.ndarray,
-    b: np.ndarray,
+@lru_cache(maxsize=1)
+def _get_tslearn_dtw():
+    try:
+        from tslearn.metrics import dtw as _ts_dtw  # type: ignore
+    except Exception:
+        return None
+    return _ts_dtw
+
+
+def _dtw_distance_python(
+    x: np.ndarray,
+    y: np.ndarray,
     *,
-    sakoe_chiba_radius: Optional[int] = None,
+    radius: Optional[int],
 ) -> float:
-    """Compute a simple 1D DTW distance without optional third-party backends."""
-    x = np.asarray(a, dtype=float).reshape(-1)
-    y = np.asarray(b, dtype=float).reshape(-1)
-
-    if x.size == 0 and y.size == 0:
-        return 0.0
-    if x.size == 0 or y.size == 0:
-        return float("inf")
-    if not np.all(np.isfinite(x)) or not np.all(np.isfinite(y)):
-        return float("inf")
-
-    radius: Optional[int] = None
-    if sakoe_chiba_radius is not None:
-        radius = max(int(sakoe_chiba_radius), abs(int(x.size) - int(y.size)))
-
     prev = np.full(y.size + 1, np.inf, dtype=float)
     prev[0] = 0.0
 
@@ -53,3 +48,43 @@ def dtw_distance_fallback(
     if not np.isfinite(distance):
         return float("inf")
     return float(sqrt(max(distance, 0.0)))
+
+
+def dtw_distance_fallback(
+    a: np.ndarray,
+    b: np.ndarray,
+    *,
+    sakoe_chiba_radius: Optional[int] = None,
+) -> float:
+    """Compute a 1D DTW distance with an optional tslearn fast path."""
+    x = np.asarray(a, dtype=float).reshape(-1)
+    y = np.asarray(b, dtype=float).reshape(-1)
+
+    if x.size == 0 and y.size == 0:
+        return 0.0
+    if x.size == 0 or y.size == 0:
+        return float("inf")
+    if not np.all(np.isfinite(x)) or not np.all(np.isfinite(y)):
+        return float("inf")
+
+    radius: Optional[int] = None
+    if sakoe_chiba_radius is not None:
+        radius = max(int(sakoe_chiba_radius), abs(int(x.size) - int(y.size)))
+
+    tslearn_dtw = _get_tslearn_dtw()
+    if tslearn_dtw is not None:
+        try:
+            if radius is None:
+                return float(tslearn_dtw(x, y))
+            return float(
+                tslearn_dtw(
+                    x,
+                    y,
+                    global_constraint="sakoe_chiba",
+                    sakoe_chiba_radius=int(radius),
+                )
+            )
+        except Exception:
+            pass
+
+    return _dtw_distance_python(x, y, radius=radius)

--- a/tests/utils/test_dtw.py
+++ b/tests/utils/test_dtw.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from mtdata.utils import dtw as dtw_mod
+
+
+def test_dtw_distance_fallback_prefers_tslearn_when_available(monkeypatch):
+    captured = {}
+
+    def fake_dtw(x, y, **kwargs):
+        captured["x"] = x.copy()
+        captured["y"] = y.copy()
+        captured["kwargs"] = kwargs
+        return 1.25
+
+    monkeypatch.setattr(dtw_mod, "_get_tslearn_dtw", lambda: fake_dtw)
+
+    result = dtw_mod.dtw_distance_fallback(
+        np.array([1.0, 2.0, 3.0]),
+        np.array([2.0, 3.0, 4.0]),
+        sakoe_chiba_radius=1,
+    )
+
+    assert result == 1.25
+    np.testing.assert_array_equal(captured["x"], np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(captured["y"], np.array([2.0, 3.0, 4.0]))
+    assert captured["kwargs"] == {
+        "global_constraint": "sakoe_chiba",
+        "sakoe_chiba_radius": 1,
+    }
+
+
+def test_dtw_distance_fallback_keeps_python_fallback_on_backend_error(monkeypatch):
+    def raising_backend(*args, **kwargs):
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr(dtw_mod, "_get_tslearn_dtw", lambda: raising_backend)
+
+    result = dtw_mod.dtw_distance_fallback(
+        np.array([1.0, 2.0, 3.0]),
+        np.array([1.0, 2.0, 3.0]),
+    )
+
+    assert result == 0.0


### PR DESCRIPTION
## Summary
- route DTW fallback through tslearn when it is importable and usable
- keep the existing pure-Python implementation as the safety net for missing or failing backends
- add focused tests for both the tslearn fast path and the preserved fallback path

## Validation
- python -m ruff check src\\mtdata\\utils\\dtw.py tests\\utils\\test_dtw.py
- python -m pytest tests\\utils\\test_dtw.py tests\\patterns\\test_classic_impl_utils.py tests\\patterns\\test_patterns_utils_pure.py -k dtw