### PR TITLE
forecast: add guarded neural early stopping

### DIFF
--- a/src/mtdata/forecast/common.py
+++ b/src/mtdata/forecast/common.py
@@ -371,7 +371,7 @@ def pd_freq_from_timeframe(tf: str) -> str:
     }
     return mapping.get(t, 'D')
 
-
+
 # ------------------------------------------------------------------
 # Composable NeuralForecast building blocks (used by train/predict)
 # ------------------------------------------------------------------
@@ -403,6 +403,8 @@ def nf_build_model_kwargs(
     input_size: int,
     batch_size: int,
     steps: int,
+    val_size: Optional[int] = None,
+    early_stop_patience_steps: Optional[int] = None,
     learning_rate: Optional[float] = None,
     accel: Optional[str] = None,
     enable_progress_bar: bool = False,
@@ -433,6 +435,14 @@ def nf_build_model_kwargs(
         model_kwargs['max_epochs'] = int(steps)
     else:
         model_kwargs['max_steps'] = int(steps)
+    if val_size is not None and int(val_size) > 0 and 'val_size' in ctor_params:
+        model_kwargs['val_size'] = int(val_size)
+    if (
+        early_stop_patience_steps is not None
+        and int(early_stop_patience_steps) > 0
+        and 'early_stop_patience_steps' in ctor_params
+    ):
+        model_kwargs['early_stop_patience_steps'] = int(early_stop_patience_steps)
     if learning_rate is not None:
         try:
             model_kwargs['learning_rate'] = float(learning_rate)
@@ -567,6 +577,7 @@ def nf_create_and_fit(
     model_kwargs: Dict[str, Any],
     timeframe: str,
     Y_df: pd.DataFrame,
+    val_size: Optional[int] = None,
     exog_used: Optional[np.ndarray] = None,
     exog_future: Optional[np.ndarray] = None,
     future_times: Optional[List[float]] = None,
@@ -616,15 +627,22 @@ def nf_create_and_fit(
         except Exception:
             _fit_params = {}
         supports_x = 'X_df' in _fit_params
+        supports_val_size = 'val_size' in _fit_params
 
         if exog_used is not None and isinstance(exog_used, np.ndarray) and exog_used.size and supports_x:
             X_df = pd.DataFrame({'unique_id': ['ts'] * len(Y_df), 'ds': Y_df['ds'].values})
             cols = [f'x{i}' for i in range(exog_used.shape[1])]
             for j, cname in enumerate(cols):
                 X_df[cname] = exog_used[:, j]
-            nf.fit(df=Y_df, X_df=X_df, verbose=False)
+            fit_kwargs: Dict[str, Any] = {'df': Y_df, 'X_df': X_df, 'verbose': False}
+            if val_size is not None and int(val_size) > 0 and supports_val_size:
+                fit_kwargs['val_size'] = int(val_size)
+            nf.fit(**fit_kwargs)
         else:
-            nf.fit(df=Y_df, verbose=False)
+            fit_kwargs = {'df': Y_df, 'verbose': False}
+            if val_size is not None and int(val_size) > 0 and supports_val_size:
+                fit_kwargs['val_size'] = int(val_size)
+            nf.fit(**fit_kwargs)
 
     return nf
 
@@ -681,6 +699,8 @@ def nf_setup_and_predict(  # noqa: C901
     input_size: int,
     batch_size: int,
     steps: int,
+    val_size: Optional[int] = None,
+    early_stop_patience_steps: Optional[int] = None,
     learning_rate: Optional[float] = None,
     exog_used: Optional[np.ndarray] = None,
     exog_future: Optional[np.ndarray] = None,
@@ -710,6 +730,14 @@ def nf_setup_and_predict(  # noqa: C901
         model_kwargs['max_epochs'] = int(steps)
     else:
         model_kwargs['max_steps'] = int(steps)
+    if val_size is not None and int(val_size) > 0 and 'val_size' in ctor_params:
+        model_kwargs['val_size'] = int(val_size)
+    if (
+        early_stop_patience_steps is not None
+        and int(early_stop_patience_steps) > 0
+        and 'early_stop_patience_steps' in ctor_params
+    ):
+        model_kwargs['early_stop_patience_steps'] = int(early_stop_patience_steps)
     if learning_rate is not None:
         try:
             model_kwargs['learning_rate'] = float(learning_rate)
@@ -848,6 +876,7 @@ def nf_setup_and_predict(  # noqa: C901
                 except Exception:
                     _pred_params = {}
                 supports_x = ('X_df' in _fit_params) and ('X_df' in _pred_params)
+                supports_val_size = 'val_size' in _fit_params
 
                 if exog_used is not None and isinstance(exog_used, np.ndarray) and exog_used.size and supports_x:
                     # Build X_df and X_future for NF (newer API)
@@ -855,7 +884,10 @@ def nf_setup_and_predict(  # noqa: C901
                     cols = [f'x{i}' for i in range(exog_used.shape[1])]
                     for j, cname in enumerate(cols):
                         X_df[cname] = exog_used[:, j]
-                    nf.fit(df=Y_df, X_df=X_df, verbose=False)  # type: ignore
+                    fit_kwargs: Dict[str, Any] = {'df': Y_df, 'X_df': X_df, 'verbose': False}
+                    if val_size is not None and int(val_size) > 0 and supports_val_size:
+                        fit_kwargs['val_size'] = int(val_size)
+                    nf.fit(**fit_kwargs)  # type: ignore[arg-type]
                     if exog_future is not None and isinstance(exog_future, np.ndarray) and exog_future.size and future_times is not None:
                         ds_f = pd.to_datetime(pd.Series(future_times), unit='s', utc=True)
                         Xf_df = pd.DataFrame({'unique_id': ['ts'] * int(len(ds_f)), 'ds': pd.Index(ds_f).to_pydatetime()})
@@ -871,7 +903,10 @@ def nf_setup_and_predict(  # noqa: C901
                         else:
                             Yf = nf.predict()  # type: ignore
                 else:
-                    nf.fit(df=Y_df, verbose=False)  # type: ignore
+                    fit_kwargs = {'df': Y_df, 'verbose': False}
+                    if val_size is not None and int(val_size) > 0 and supports_val_size:
+                        fit_kwargs['val_size'] = int(val_size)
+                    nf.fit(**fit_kwargs)  # type: ignore[arg-type]
                     if 'h' in _pred_params:
                         Yf = nf.predict(h=int(fh))  # type: ignore
                     else:
@@ -991,4 +1026,3 @@ def fetch_history(
         if not start and len(df) > need:
             df = df.iloc[-int(need):]
     return df.reset_index(drop=True)
-

--- a/src/mtdata/forecast/methods/neural.py
+++ b/src/mtdata/forecast/methods/neural.py
@@ -112,6 +112,9 @@ def forecast_neural(
     steps = int(params.get('max_steps', params.get('max_epochs', 50)))
     batch_size = int(params.get('batch_size', 32))
     lr = params.get('learning_rate', None)
+    val_size, early_stop_patience_steps = _neural_resolve_validation_settings(
+        params, n, int(fh), steps,
+    )
 
     Yf = _nf_setup_and_predict(
         model_class=model_class,
@@ -121,6 +124,8 @@ def forecast_neural(
         input_size=int(input_size),
         batch_size=int(batch_size),
         steps=int(steps),
+        val_size=val_size,
+        early_stop_patience_steps=early_stop_patience_steps,
         learning_rate=float(lr) if lr is not None else None,
         exog_used=exog_used,
         exog_future=exog_future,
@@ -136,7 +141,15 @@ def forecast_neural(
         f"{method_l.upper()} forecast",
         allow_actual_fallback=False,
     )
-    params_used = {'max_epochs': int(steps), 'input_size': int(input_size), 'batch_size': int(batch_size)}
+    params_used = {
+        'max_epochs': int(steps),
+        'input_size': int(input_size),
+        'batch_size': int(batch_size),
+    }
+    if val_size > 0:
+        params_used['val_size'] = int(val_size)
+    if early_stop_patience_steps is not None:
+        params_used['early_stop_patience_steps'] = int(early_stop_patience_steps)
     return f_vals.astype(float, copy=False), params_used
 
 
@@ -167,6 +180,29 @@ def _neural_resolve_hyperparams(
     return input_size, steps, batch_size, float(lr) if lr is not None else None
 
 
+def _neural_resolve_validation_settings(
+    params: Dict[str, Any], n: int, fh: int, steps: int,
+) -> Tuple[int, Optional[int]]:
+    raw_val_size = params.get("val_size")
+    if raw_val_size is None:
+        available = max(0, int(n) - int(fh) - 1)
+        if available <= 0:
+            val_size = 0
+        else:
+            val_size = min(available, max(int(fh), int(n) // 5))
+    else:
+        val_size = max(0, min(int(raw_val_size), max(0, int(n) - 1)))
+
+    raw_patience = params.get("early_stop_patience_steps")
+    if val_size <= 0:
+        return 0, None
+    if raw_patience is None:
+        patience = min(max(5, int(steps) // 5), max(1, int(steps) - 1))
+    else:
+        patience = max(0, int(raw_patience))
+    return int(val_size), (int(patience) if patience > 0 else None)
+
+
 class NeuralForecastMethod(ForecastMethod):
     PARAMS: List[Dict[str, Any]] = [
         {"name": "input_size", "type": "int|null", "description": "Lookback context for the model (auto if omitted)."},
@@ -174,6 +210,12 @@ class NeuralForecastMethod(ForecastMethod):
         {"name": "max_epochs", "type": "int|null", "description": "Alias for max_steps."},
         {"name": "batch_size", "type": "int", "description": "Batch size (default: 32)."},
         {"name": "learning_rate", "type": "float|null", "description": "Learning rate (model default if omitted)."},
+        {"name": "val_size", "type": "int|null", "description": "Validation window for early stopping (auto if omitted)."},
+        {
+            "name": "early_stop_patience_steps",
+            "type": "int|null",
+            "description": "Stop training early after this many non-improving validation checks (auto if omitted).",
+        },
     ]
 
     @property
@@ -238,6 +280,9 @@ class NeuralForecastMethod(ForecastMethod):
         input_size, steps, batch_size, lr = _neural_resolve_hyperparams(
             p, n, int(horizon), int(seasonality or 0),
         )
+        val_size, early_stop_patience_steps = _neural_resolve_validation_settings(
+            p, n, int(horizon), steps,
+        )
         timeframe = str(p.get("timeframe") or kwargs.get("timeframe") or "H1")
         model_class = _resolve_nf_model_class(self.name)
 
@@ -254,6 +299,8 @@ class NeuralForecastMethod(ForecastMethod):
             input_size=input_size,
             batch_size=batch_size,
             steps=steps,
+            val_size=val_size,
+            early_stop_patience_steps=early_stop_patience_steps,
             learning_rate=lr,
             accel=accel,
         )
@@ -265,6 +312,7 @@ class NeuralForecastMethod(ForecastMethod):
                     model_kwargs=model_kwargs,
                     timeframe=timeframe,
                     Y_df=Y_df,
+                    val_size=val_size,
                     exog_used=exog_used,
                 )
 
@@ -275,6 +323,10 @@ class NeuralForecastMethod(ForecastMethod):
             'max_epochs': steps, 'input_size': input_size,
             'batch_size': batch_size,
         }
+        if val_size > 0:
+            params_used['val_size'] = val_size
+        if early_stop_patience_steps is not None:
+            params_used['early_stop_patience_steps'] = early_stop_patience_steps
         return TrainResult(
             artifact_bytes=artifact_bytes,
             params_used=params_used,

--- a/tests/forecast/test_forecast_common_extended.py
+++ b/tests/forecast/test_forecast_common_extended.py
@@ -22,6 +22,7 @@ from mtdata.forecast.common import (
     nf_setup_and_predict,
     pd_freq_from_timeframe,
 )
+from mtdata.forecast.methods.neural import _neural_resolve_validation_settings
 
 # ---------------------------------------------------------------------------
 # nf_setup_and_predict (lines 159-345) — heavily mocked
@@ -97,6 +98,11 @@ class TestNfSetupAndPredict:
         assert "max_steps" not in sig.parameters
         assert "max_epochs" not in sig.parameters
 
+    def test_validation_settings_choose_reasonable_defaults(self):
+        val_size, patience = _neural_resolve_validation_settings({}, n=100, fh=12, steps=50)
+        assert val_size == 20
+        assert patience == 10
+
     @patch("mtdata.forecast.common.pd_freq_from_timeframe", return_value="1h")
     def test_basic_predict_mocked_nf(self, mock_freq):
         """End-to-end with fully mocked NeuralForecast."""
@@ -108,7 +114,8 @@ class TestNfSetupAndPredict:
                        inspect.Parameter("h", inspect.Parameter.KEYWORD_ONLY, default=None)]
         mock_nf_inst.predict.__signature__ = inspect.Signature(pred_params)
         fit_params = [inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
-                      inspect.Parameter("df", inspect.Parameter.KEYWORD_ONLY)]
+                      inspect.Parameter("df", inspect.Parameter.KEYWORD_ONLY),
+                      inspect.Parameter("val_size", inspect.Parameter.KEYWORD_ONLY, default=None)]
         mock_nf_inst.fit.__signature__ = inspect.Signature(fit_params)
 
         # Build a callable that mimics NeuralForecast class — returns the mock instance
@@ -130,9 +137,10 @@ class TestNfSetupAndPredict:
         with patch.dict("sys.modules", {"neuralforecast": nf_module}):
             result = nf_setup_and_predict(
                 model_class=model_cls, fh=10, timeframe="H1",
-                Y_df=_make_y_df(), input_size=24, batch_size=32, steps=5,
+                Y_df=_make_y_df(), input_size=24, batch_size=32, steps=5, val_size=12,
             )
         assert isinstance(result, pd.DataFrame)
+        assert mock_nf_inst.fit.call_args.kwargs["val_size"] == 12
 
     @patch("mtdata.forecast.common.pd_freq_from_timeframe", return_value="1h")
     def test_restores_environment_after_prediction(self, mock_freq, monkeypatch):

--- a/tests/forecast/test_neural_coverage.py
+++ b/tests/forecast/test_neural_coverage.py
@@ -155,6 +155,8 @@ class TestForecastNeural:
             params={"max_steps": 100}, Y_df=Y_df,
         )
         assert pu["max_epochs"] == 100
+        assert pu["val_size"] == 20
+        assert pu["early_stop_patience_steps"] == 20
 
     @patch("mtdata.forecast.methods.neural._nf_setup_and_predict")
     @patch("mtdata.forecast.methods.neural._edge_pad_to_length", side_effect=lambda v, l: v[:l] if len(v) >= l else np.pad(v, (0, l - len(v)), mode="edge"))
@@ -228,6 +230,23 @@ class TestForecastNeural:
             Y_df=Y_df,
         )
         assert pu["input_size"] == 88
+
+    @patch("mtdata.forecast.methods.neural._nf_setup_and_predict")
+    def test_small_series_disables_early_stopping(self, predict_mock):
+        predict_mock.return_value = _make_Yf(4)
+        Y_df = pd.DataFrame({"unique_id": ["ts"] * 9, "ds": list(range(9)), "y": np.linspace(100, 103, 9)})
+        _vals, pu = forecast_neural(
+            method="nhits",
+            series=np.linspace(100, 103, 9),
+            fh=8,
+            timeframe="H1",
+            n=9,
+            m=0,
+            params={},
+            Y_df=Y_df,
+        )
+        assert "val_size" not in pu
+        assert "early_stop_patience_steps" not in pu
 
 
 # ── NeuralForecastMethod and subclasses  (lines 90-177) ─────────────────────


### PR DESCRIPTION
## Summary
- derive validation windows and early-stop patience for neural methods when enough history is available
- pass al_size to NeuralForecast it() and arly_stop_patience_steps to model constructors only when the installed stack supports them
- add focused coverage for the new validation-setting and fit forwarding behavior

## Validation
- python -m pytest tests/forecast/test_neural_coverage.py tests/forecast/test_forecast_common_extended.py -q