### PR TITLE
regime: vectorize GARCH rolling volatility

### DIFF
--- a/src/mtdata/core/regime/api.py
+++ b/src/mtdata/core/regime/api.py
@@ -86,6 +86,43 @@ def _summary_window_size(lookback: int, size: int) -> int:
     return min(max(lookback_i, 0), int(size))
 
 
+def _trailing_window_std(values: np.ndarray, window: int) -> np.ndarray:
+    data = np.asarray(values, dtype=float)
+    if data.size == 0:
+        return np.empty(0, dtype=float)
+
+    window_i = max(0, int(window))
+    indices = np.arange(data.size, dtype=int)
+    starts = np.maximum(indices - window_i, 0)
+    counts = indices - starts + 1
+
+    finite = np.isfinite(data)
+    safe_values = np.where(finite, data, 0.0)
+    safe_sq_values = safe_values * safe_values
+
+    cumsum = np.zeros(data.size + 1, dtype=float)
+    cumsum_sq = np.zeros(data.size + 1, dtype=float)
+    cumsum_finite = np.zeros(data.size + 1, dtype=int)
+    np.cumsum(safe_values, out=cumsum[1:])
+    np.cumsum(safe_sq_values, out=cumsum_sq[1:])
+    np.cumsum(finite.astype(int), out=cumsum_finite[1:])
+
+    window_sum = cumsum[1:] - cumsum[starts]
+    window_sq_sum = cumsum_sq[1:] - cumsum_sq[starts]
+    finite_counts = cumsum_finite[1:] - cumsum_finite[starts]
+    valid = finite_counts == counts
+
+    result = np.full(data.size, np.nan, dtype=float)
+    if not np.any(valid):
+        return result
+
+    valid_counts = counts[valid].astype(float)
+    mean = window_sum[valid] / valid_counts
+    variance = (window_sq_sum[valid] / valid_counts) - (mean * mean)
+    result[valid] = np.sqrt(np.maximum(variance, 0.0))
+    return result
+
+
 def _history_fetch_limit(limit: Optional[int], lookback: int) -> int:
     if limit is not None and int(limit) >= 0:
         return int(max(int(limit), 50))
@@ -1947,9 +1984,7 @@ def regime_detect(  # noqa: C901
                     window = 5
 
                 # Rolling standard deviation of returns
-                rolling_vol = np.array(
-                    [np.std(x[max(0, i - window) : i + 1]) for i in range(len(x))]
-                )
+                rolling_vol = _trailing_window_std(x, window)
                 rolling_vol = rolling_vol[np.isfinite(rolling_vol) & (rolling_vol > 0)]
 
                 if len(rolling_vol) > 10:

--- a/tests/core/test_regime_output_semantics.py
+++ b/tests/core/test_regime_output_semantics.py
@@ -9,7 +9,7 @@ import pytest
 from mtdata.core import regime as regime_mod
 from mtdata.core.regime import _consolidate_payload, regime_detect
 from mtdata.core.regime import api as regime_api
-from mtdata.core.regime.api import _build_all_method_comparison
+from mtdata.core.regime.api import _build_all_method_comparison, _trailing_window_std
 from mtdata.core.regime.payload import _build_regime_descriptions
 
 
@@ -748,6 +748,20 @@ def test_garch_rejects_price_target() -> None:
 
     assert out["error_code"] == "invalid_target"
     assert "target='return'" in out["error"]
+
+
+def test_trailing_window_std_matches_naive_garch_window_scan() -> None:
+    x = np.array([0.02, -0.01, 0.03, np.nan, 0.04, -0.02, 0.01, 0.0], dtype=float)
+    window = 3
+
+    expected = np.array(
+        [np.std(x[max(0, i - window) : i + 1]) for i in range(len(x))],
+        dtype=float,
+    )
+
+    actual = _trailing_window_std(x, window)
+
+    np.testing.assert_allclose(actual, expected, equal_nan=True)
 
 
 def test_wavelet_rejects_non_positive_energy_window() -> None:


### PR DESCRIPTION
## Summary
- replace the GARCH auto-state rolling volatility Python loop with a vectorized trailing standard deviation helper
- preserve the previous windowing and NaN semantics so downstream percentile logic stays unchanged
- add a focused regression test that compares the vectorized helper against the original naive computation

## Validation
- python -m ruff check src\mtdata\core\regime\api.py tests\core\test_regime_output_semantics.py
- python -m pytest tests\core\test_regime_output_semantics.py