### PR TITLE
utils: optimize SSA SVD selection

### DIFF
--- a/src/mtdata/utils/denoise/filters/decomposition.py
+++ b/src/mtdata/utils/denoise/filters/decomposition.py
@@ -20,7 +20,54 @@ try:
 except Exception:
     _VMD = None  # type: ignore
 
+try:
+    from sklearn.utils.extmath import randomized_svd as _randomized_svd
+except Exception:
+    _randomized_svd = None  # type: ignore
+
 from ..base import _series_like, register_filter
+
+
+def _ssa_requested_rank(components: Optional[Any], max_rank: int) -> Optional[int]:
+    if components is None:
+        return min(2, max_rank)
+    if isinstance(components, float) and 0 < components <= 1:
+        return None
+    return max(1, min(int(components), max_rank))
+
+
+def _should_use_randomized_ssa_svd(shape: tuple[int, int], rank: Optional[int]) -> bool:
+    if _randomized_svd is None or rank is None:
+        return False
+    full_rank = min(shape)
+    if rank >= full_rank or full_rank < 64 or (shape[0] * shape[1]) < 8192:
+        return False
+    return rank <= max(4, full_rank // 3)
+
+
+def _ssa_svd(
+    X: np.ndarray,
+    *,
+    requested_rank: Optional[int],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    if _should_use_randomized_ssa_svd(X.shape, requested_rank):
+        assert requested_rank is not None
+        try:
+            oversamples = min(10, max(2, min(X.shape) - requested_rank))
+            U, s, Vt = _randomized_svd(
+                X,
+                n_components=requested_rank,
+                n_iter=4,
+                n_oversamples=oversamples,
+                random_state=0,
+                flip_sign=False,
+            )
+            if U.shape[1] == requested_rank and Vt.shape[0] == requested_rank and np.all(np.isfinite(s)):
+                order = np.argsort(s)[::-1]
+                return U[:, order], s[order], Vt[order, :]
+        except Exception:
+            _logger.debug("SSA randomized SVD failed; falling back to full SVD", exc_info=True)
+    return np.linalg.svd(X, full_matrices=False)
 
 
 def _ssa_denoise(
@@ -39,9 +86,10 @@ def _ssa_denoise(
         return x
     K = n - L + 1
     X = np.column_stack([x[i : i + L] for i in range(K)])
-    U, s, Vt = np.linalg.svd(X, full_matrices=False)
-    if components is None:
-        r = min(2, len(s))
+    requested_rank = _ssa_requested_rank(components, min(L, K))
+    U, s, Vt = _ssa_svd(X, requested_rank=requested_rank)
+    if requested_rank is not None:
+        r = requested_rank
     elif isinstance(components, float) and 0 < components <= 1:
         total_energy = float(np.sum(s ** 2))
         if not math.isfinite(total_energy) or total_energy <= 0.0:

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mtdata.utils.denoise import api as denoise_api
-from mtdata.utils.denoise.api import _run_denoise_handler
 from mtdata.utils.denoise import (
     _apply_denoise,
     _denoise_series,
@@ -14,12 +12,14 @@ from mtdata.utils.denoise import (
     get_denoise_methods_data,
     normalize_denoise_spec,
 )
+from mtdata.utils.denoise import api as denoise_api
+from mtdata.utils.denoise.api import _run_denoise_handler
+from mtdata.utils.denoise.filters import specialized as specialized_filters
 from mtdata.utils.denoise.filters.adaptive import (
     _adaptive_lms_filter,
     _adaptive_rls_filter,
 )
 from mtdata.utils.denoise.filters.decomposition import _ssa_denoise, _vmd_denoise
-from mtdata.utils.denoise.filters import specialized as specialized_filters
 from mtdata.utils.denoise.filters.specialized import (
     _bilateral_filter_1d,
     _hampel_filter,
@@ -929,6 +929,55 @@ class TestSsaDenoise:
     def test_energy_ratio_components(self):
         y = _ssa_denoise(NOISY_SIGNAL, window=30, components=0.9)
         _check_basic(y, N)
+
+    def test_small_component_count_uses_randomized_svd(self, monkeypatch):
+        real_svd = np.linalg.svd
+        captured = {}
+
+        def fake_randomized_svd(X, **kwargs):
+            captured["shape"] = X.shape
+            captured["kwargs"] = dict(kwargs)
+            U, s, Vt = real_svd(X, full_matrices=False)
+            n_components = int(kwargs["n_components"])
+            return U[:, :n_components], s[:n_components], Vt[:n_components, :]
+
+        monkeypatch.setattr(
+            "mtdata.utils.denoise.filters.decomposition._randomized_svd",
+            fake_randomized_svd,
+        )
+        monkeypatch.setattr(
+            "mtdata.utils.denoise.filters.decomposition.np.linalg.svd",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("full svd should be skipped")),
+        )
+
+        y = _ssa_denoise(NOISY_SIGNAL, window=80, components=2)
+
+        _check_basic(y, N)
+        assert captured["shape"] == (80, N - 80 + 1)
+        assert captured["kwargs"]["n_components"] == 2
+        assert captured["kwargs"]["random_state"] == 0
+
+    def test_energy_ratio_components_keep_full_svd_for_exact_rank_selection(self, monkeypatch):
+        real_svd = np.linalg.svd
+        calls = {"count": 0}
+
+        def counting_svd(*args, **kwargs):
+            calls["count"] += 1
+            return real_svd(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "mtdata.utils.denoise.filters.decomposition._randomized_svd",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("randomized svd should be skipped")),
+        )
+        monkeypatch.setattr(
+            "mtdata.utils.denoise.filters.decomposition.np.linalg.svd",
+            counting_svd,
+        )
+
+        y = _ssa_denoise(NOISY_SIGNAL, window=80, components=0.9)
+
+        _check_basic(y, N)
+        assert calls["count"] == 1
 
     def test_short_array(self):
         y = _ssa_denoise(np.array([1.0, 2.0, 3.0]), window=10, components=2)


### PR DESCRIPTION
## Summary
- add a guarded randomized SVD path for large SSA trajectory matrices when only a small integer component count is needed
- keep full SVD for energy-ratio component selection and fall back safely if the truncated path fails
- cover both backend-selection paths in focused SSA tests

## Validation
- python -m ruff check src\mtdata\utils\denoise\filters\decomposition.py tests\utils\test_denoise_pure.py
- python -m pytest tests\utils\test_denoise_pure.py