### PR TITLE
utils: use sliding SSA trajectory views

### DIFF
--- a/src/mtdata/utils/denoise/filters/decomposition.py
+++ b/src/mtdata/utils/denoise/filters/decomposition.py
@@ -23,6 +23,14 @@ except Exception:
 from ..base import _series_like, register_filter
 
 
+def _ssa_trajectory_matrix(x: np.ndarray, window: int) -> np.ndarray:
+    try:
+        return np.lib.stride_tricks.sliding_window_view(x, window).T
+    except Exception:
+        K = len(x) - window + 1
+        return np.column_stack([x[i : i + window] for i in range(K)])
+
+
 def _ssa_denoise(
     x: np.ndarray,
     window: int,
@@ -38,7 +46,9 @@ def _ssa_denoise(
     if L >= n:
         return x
     K = n - L + 1
-    X = np.column_stack([x[i : i + L] for i in range(K)])
+    X = _ssa_trajectory_matrix(x, L)
+    if X.shape != (L, K):
+        X = np.column_stack([x[i : i + L] for i in range(K)])
     U, s, Vt = np.linalg.svd(X, full_matrices=False)
     if components is None:
         r = min(2, len(s))

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mtdata.utils.denoise import api as denoise_api
-from mtdata.utils.denoise.api import _run_denoise_handler
 from mtdata.utils.denoise import (
     _apply_denoise,
     _denoise_series,
@@ -14,12 +12,18 @@ from mtdata.utils.denoise import (
     get_denoise_methods_data,
     normalize_denoise_spec,
 )
+from mtdata.utils.denoise import api as denoise_api
+from mtdata.utils.denoise.api import _run_denoise_handler
+from mtdata.utils.denoise.filters import specialized as specialized_filters
 from mtdata.utils.denoise.filters.adaptive import (
     _adaptive_lms_filter,
     _adaptive_rls_filter,
 )
-from mtdata.utils.denoise.filters.decomposition import _ssa_denoise, _vmd_denoise
-from mtdata.utils.denoise.filters import specialized as specialized_filters
+from mtdata.utils.denoise.filters.decomposition import (
+    _ssa_denoise,
+    _ssa_trajectory_matrix,
+    _vmd_denoise,
+)
 from mtdata.utils.denoise.filters.specialized import (
     _bilateral_filter_1d,
     _hampel_filter,
@@ -921,6 +925,16 @@ class TestAdaptiveRlsFilter:
 
 
 class TestSsaDenoise:
+    def test_trajectory_matrix_uses_sliding_window_view(self):
+        x = np.arange(12.0, dtype=float)
+
+        X = _ssa_trajectory_matrix(x, 4)
+
+        assert X.shape == (4, 9)
+        assert np.shares_memory(X, x)
+        np.testing.assert_array_equal(X[:, 0], np.array([0.0, 1.0, 2.0, 3.0]))
+        np.testing.assert_array_equal(X[:, -1], np.array([8.0, 9.0, 10.0, 11.0]))
+
     def test_basic(self):
         y = _ssa_denoise(NOISY_SIGNAL, window=30, components=2)
         _check_basic(y, N)


### PR DESCRIPTION
## Summary
- build SSA trajectory matrices from NumPy sliding-window views to avoid per-column copying on the hot path
- preserve the existing copy-based construction as a safety fallback when a strided view cannot be used
- add a focused test that locks in the shared-memory trajectory layout

## Validation
- python -m ruff check src\mtdata\utils\denoise\filters\decomposition.py tests\utils\test_denoise_pure.py
- python -m pytest tests\utils\test_denoise_pure.py