### PR TITLE
regime: use temporal Gaussian HMM backend

### DIFF
--- a/src/mtdata/core/regime/api.py
+++ b/src/mtdata/core/regime/api.py
@@ -34,7 +34,7 @@ from .methods.bocpd import (
     _filter_bocpd_change_points,
     _walkforward_quantile_threshold_calibration,
 )
-from .methods.hmm import _hmm_reliability_from_gamma
+from .methods.hmm import _hmm_reliability_from_gamma, fit_temporal_gaussian_hmm_1d
 from .methods.ms_ar import _ms_ar_reliability_from_smoothed
 from .payload import (
     _consolidate_payload,
@@ -1513,7 +1513,7 @@ def regime_detect(  # noqa: C901
                 )
             )
 
-        elif method == "hmm":  # 'hmm' (mixture/HMM-lite)
+        elif method == "hmm":
             n_states, n_states_error, n_states_source, state_count_warnings = (
                 _resolve_state_count_param(
                     p,
@@ -1525,14 +1525,56 @@ def regime_detect(  # noqa: C901
                 return _finish({"error": n_states_error})
             if n_states is None or n_states < 2:
                 return _finish({"error": "n_states must be >= 2 for hmm."})
+            hmm_fit_warnings: List[str] = []
+            hmm_meta: Dict[str, Any] = {}
+            temporal_hmm_error: Optional[Exception] = None
             try:
-                from ...forecast.monte_carlo import fit_gaussian_mixture_1d
+                fit_hmm = globals().get(
+                    "fit_temporal_gaussian_hmm_1d",
+                    fit_temporal_gaussian_hmm_1d,
+                )
+                w, mu, sigma, gamma, hmm_meta = fit_hmm(x, n_states=n_states)
+                if not isinstance(hmm_meta, dict):
+                    hmm_meta = {}
             except Exception as ex:
-                return _finish({"error": f"HMM-lite import error: {ex}"})
-            fit_gaussian_mixture_1d = globals().get(
-                "fit_gaussian_mixture_1d", fit_gaussian_mixture_1d
-            )
-            w, mu, sigma, gamma, _ = fit_gaussian_mixture_1d(x, n_states=n_states)
+                temporal_hmm_error = ex
+                try:
+                    from ...forecast.monte_carlo import fit_gaussian_mixture_1d
+                except Exception as fallback_import_ex:
+                    return _finish(
+                        {
+                            "error": "Temporal Gaussian HMM failed "
+                            f"({ex}) and Gaussian-mixture fallback import also failed "
+                            f"({fallback_import_ex})."
+                        }
+                    )
+                fit_gaussian_mixture_1d = globals().get(
+                    "fit_gaussian_mixture_1d", fit_gaussian_mixture_1d
+                )
+                try:
+                    w, mu, sigma, gamma, fallback_ll = fit_gaussian_mixture_1d(
+                        x, n_states=n_states
+                    )
+                except Exception as fallback_ex:
+                    return _finish(
+                        {
+                            "error": "Temporal Gaussian HMM failed "
+                            f"({ex}) and Gaussian-mixture fallback also failed "
+                            f"({fallback_ex})."
+                        }
+                    )
+                hmm_meta = {
+                    "backend": "gaussian_mixture_fallback",
+                    "fallback_reason": str(ex),
+                    "temporal_model": False,
+                }
+                fallback_ll_value = _coerce_optional_float(fallback_ll)
+                if fallback_ll_value is not None:
+                    hmm_meta["log_likelihood"] = float(fallback_ll_value)
+                hmm_fit_warnings.append(
+                    "Temporal Gaussian HMM fit failed; fell back to a non-temporal "
+                    f"Gaussian mixture. Original error: {ex}"
+                )
             gamma_matrix = _normalize_state_probability_matrix(
                 gamma,
                 rows=x.size,
@@ -1580,6 +1622,14 @@ def regime_detect(  # noqa: C901
                     "n_states": int(n_states),
                     "fitted_n_states": int(len(mu)),
                     "state_count_param": n_states_source,
+                    "backend": str(hmm_meta.get("backend", "gaussian_hmm")),
+                    "temporal_model": bool(
+                        hmm_meta.get(
+                            "temporal_model",
+                            str(hmm_meta.get("backend", "gaussian_hmm"))
+                            == "gaussian_hmm",
+                        )
+                    ),
                     "min_regime_bars": int(min_regime_bars_val),
                     "relabeled": bool(canon_meta.get("relabeled", False)),
                     "smoothing_applied": bool(
@@ -1593,8 +1643,11 @@ def regime_detect(  # noqa: C901
                     ),
                 },
             }
+            if temporal_hmm_error is not None:
+                payload["params_used"]["fallback_reason"] = str(temporal_hmm_error)
             if canon_meta.get("mapping"):
                 payload["params_used"]["label_mapping"] = canon_meta["mapping"]
+            _append_warnings(payload, hmm_fit_warnings)
             _append_warnings(payload, state_count_warnings)
             _append_warnings(payload, _smoothing_warnings(method, smoothing_meta))
             # Add reliability info

--- a/src/mtdata/core/regime/methods/hmm/__init__.py
+++ b/src/mtdata/core/regime/methods/hmm/__init__.py
@@ -1,4 +1,4 @@
 """HMM method package."""
-from .core import _hmm_reliability_from_gamma
+from .core import _hmm_reliability_from_gamma, fit_temporal_gaussian_hmm_1d
 
-__all__ = ["_hmm_reliability_from_gamma"]
+__all__ = ["_hmm_reliability_from_gamma", "fit_temporal_gaussian_hmm_1d"]

--- a/src/mtdata/core/regime/methods/hmm/core.py
+++ b/src/mtdata/core/regime/methods/hmm/core.py
@@ -1,5 +1,9 @@
 """HMM (Hidden Markov Model) regime detection."""
-from typing import Any, Dict
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -40,4 +44,90 @@ def _hmm_reliability_from_gamma(gamma: np.ndarray) -> Dict[str, Any]:
     return {"confidence": round(reliability, 4), "entropy_trend": trend}
 
 
-__all__ = ["_hmm_reliability_from_gamma"]
+def fit_temporal_gaussian_hmm_1d(
+    x: np.ndarray,
+    *,
+    n_states: int = 2,
+    max_iter: int = 80,
+    tol: float = 1e-6,
+    seed: Optional[int] = 42,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, Dict[str, Any]]:
+    """Fit a true temporal Gaussian HMM and expose regime payload inputs.
+
+    Returns ``(weights, mu, sigma, gamma, metadata)`` where ``gamma`` contains
+    smoothed state posteriors for each observation and ``weights`` are the mean
+    posterior occupancies. State order is canonicalized to ascending mean so the
+    surrounding regime payload keeps its stable label semantics.
+    """
+    from mtdata.forecast.monte_carlo import (
+        _is_hmm_degenerate,
+        _normalize_probability_vector,
+        _normalize_transition_matrix,
+    )
+    from hmmlearn.hmm import GaussianHMM
+
+    x = np.asarray(x, dtype=float).reshape(-1)
+    x = x[np.isfinite(x)]
+    n_obs = int(x.size)
+    requested_states = max(1, int(n_states))
+    if n_obs < max(4, requested_states + 1):
+        raise ValueError("Not enough observations for temporal Gaussian HMM calibration")
+
+    x2 = x.reshape(-1, 1)
+    model: Optional[GaussianHMM] = None
+    fitted_states = requested_states
+    for fitted_states in range(requested_states, 0, -1):
+        model = GaussianHMM(
+            n_components=fitted_states,
+            covariance_type="diag",
+            n_iter=int(max_iter),
+            tol=float(tol),
+            random_state=seed,
+            init_params="stc",
+        )
+        quantiles = np.linspace(0.0, 1.0, fitted_states + 2, dtype=float)[1:-1]
+        model.means_ = np.quantile(x, quantiles).reshape(fitted_states, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            model.fit(x2)
+        if fitted_states == 1 or not _is_hmm_degenerate(
+            model, x2, fitted_states, n_obs
+        ):
+            break
+
+    if model is None:
+        raise RuntimeError("Temporal Gaussian HMM fit did not produce a model")
+
+    gamma = np.asarray(model.predict_proba(x2), dtype=float)
+    mu = np.asarray(model.means_, dtype=float).reshape(-1)
+    covars = np.asarray(model.covars_, dtype=float).reshape(fitted_states, -1)[:, 0]
+    sigma = np.sqrt(np.clip(covars, 1e-12, None))
+    weights = _normalize_probability_vector(np.mean(gamma, axis=0))
+    transition_matrix = _normalize_transition_matrix(
+        np.asarray(model.transmat_, dtype=float)
+    )
+    initial_state_probabilities = _normalize_probability_vector(
+        np.asarray(getattr(model, "startprob_", gamma[0]), dtype=float)
+    )
+    log_likelihood = float(model.score(x2) * n_obs)
+
+    order = np.argsort(mu)
+    gamma = gamma[:, order]
+    weights = _normalize_probability_vector(weights[order])
+    mu = mu[order]
+    sigma = sigma[order]
+    transition_matrix = transition_matrix[np.ix_(order, order)]
+    initial_state_probabilities = _normalize_probability_vector(
+        initial_state_probabilities[order]
+    )
+    metadata = {
+        "backend": "gaussian_hmm",
+        "fitted_n_states": int(fitted_states),
+        "transition_matrix": transition_matrix,
+        "initial_state_probabilities": initial_state_probabilities,
+        "log_likelihood": log_likelihood,
+    }
+    return weights, mu, sigma, gamma, metadata
+
+
+__all__ = ["_hmm_reliability_from_gamma", "fit_temporal_gaussian_hmm_1d"]

--- a/tests/core/test_regime_core_coverage.py
+++ b/tests/core/test_regime_core_coverage.py
@@ -869,7 +869,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001])
         sigma = np.array([0.001, 0.003])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -890,7 +890,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001])
         sigma = np.array([0.001, 0.003])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -910,7 +910,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001])
         sigma = np.array([0.001, 0.003])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -930,7 +930,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001])
         sigma = np.array([0.001, 0.003])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -957,7 +957,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001])
         sigma = np.array([0.001, 0.003])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -976,14 +976,33 @@ class TestRegimeDetectHMM:
     @patch(_FMT, side_effect=_time_fmt_stub)
     @patch(_DENOISE, return_value="close")
     @patch(_FETCH)
-    def test_hmm_import_error(self, mock_fetch, mock_denoise, mock_fmt):
+    def test_hmm_fallback_warning_when_temporal_hmm_fails(
+        self, mock_fetch, mock_denoise, mock_fmt
+    ):
         df = _make_df(50)
         mock_fetch.return_value = df
-        with patch.dict("sys.modules", {"mtdata.forecast.monte_carlo": None}):
+        gamma = np.ones((49, 1), dtype=float)
+        w = np.array([1.0])
+        mu = np.array([0.0])
+        sigma = np.array([0.001])
+        with (
+            patch(
+                "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
+                side_effect=RuntimeError("temporal hmm failed"),
+                create=True,
+            ),
+            patch(
+                "mtdata.forecast.monte_carlo.fit_gaussian_mixture_1d",
+                return_value=(w, mu, sigma, gamma, None),
+                create=True,
+            ),
+        ):
             fn = _get_regime_detect()
-            res = fn("EURUSD", limit=50, method="hmm")
-        # Should return an error about import
+            res = fn("EURUSD", limit=50, method="hmm", detail="full")
         assert isinstance(res, dict)
+        assert res.get("success") is True
+        assert res.get("params_used", {}).get("backend") == "gaussian_mixture_fallback"
+        assert "fell back" in " ".join(res.get("warnings", [])).lower()
 
     @patch(_FMT, side_effect=_time_fmt_stub)
     @patch(_DENOISE, return_value="close")
@@ -997,7 +1016,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001])
         sigma = np.array([0.001, 0.003])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -1018,7 +1037,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0])
         sigma = np.array([0.001])
         with patch(
-            "mtdata.forecast.monte_carlo.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -1048,7 +1067,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.0, 0.001, -0.001])
         sigma = np.array([0.001, 0.003, 0.002])
         with patch(
-            "mtdata.core.regime.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -1101,7 +1120,7 @@ class TestRegimeDetectHMM:
         mu = np.array([0.001, -0.001])
         sigma = np.array([0.003, 0.001])
         with patch(
-            "mtdata.core.regime.api.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(w, mu, sigma, gamma, None),
             create=True,
         ):
@@ -1120,7 +1139,7 @@ class TestRegimeDetectHMM:
         df = _make_df(60)
         mock_fetch.return_value = df
         with patch(
-            "mtdata.forecast.monte_carlo.fit_gaussian_mixture_1d", create=True
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d", create=True
         ) as mock_fit:
             fn = _get_regime_detect()
             res = fn(

--- a/tests/core/test_regime_hmm_temporal.py
+++ b/tests/core/test_regime_hmm_temporal.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mtdata.core import regime as regime_mod
+from mtdata.core.regime import regime_detect
+from mtdata.core.regime.methods.hmm import fit_temporal_gaussian_hmm_1d
+
+
+def _unwrap(fn):
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+@pytest.fixture(autouse=True)
+def _skip_mt5_connection(monkeypatch):
+    monkeypatch.setattr(regime_mod, "ensure_mt5_connection_or_raise", lambda: None)
+
+
+def _history_from_returns(returns: np.ndarray) -> pd.DataFrame:
+    prices = 100.0 * np.exp(np.cumsum(np.concatenate([[0.0], returns])))
+    n = prices.size
+    return pd.DataFrame(
+        {
+            "time": np.arange(n, dtype=float) * 3600 + 1_700_000_000,
+            "open": prices,
+            "high": prices + 0.001,
+            "low": prices - 0.001,
+            "close": prices,
+            "tick_volume": np.ones(n),
+        }
+    )
+
+
+def test_fit_temporal_gaussian_hmm_1d_uses_true_hmmlearn_backend() -> None:
+    rng = np.random.default_rng(42)
+    x = np.concatenate(
+        [
+            rng.normal(-0.004, 0.0004, 40),
+            rng.normal(0.004, 0.0004, 40),
+        ]
+    )
+
+    weights, mu, sigma, gamma, meta = fit_temporal_gaussian_hmm_1d(
+        x, n_states=2, seed=42
+    )
+
+    assert meta["backend"] == "gaussian_hmm"
+    assert gamma.shape == (x.size, int(meta["fitted_n_states"]))
+    assert meta["transition_matrix"].shape == (
+        int(meta["fitted_n_states"]),
+        int(meta["fitted_n_states"]),
+    )
+    assert np.all(np.diag(meta["transition_matrix"]) > 0.5)
+    assert np.all(np.diff(mu) >= 0.0)
+    assert np.isclose(weights.sum(), 1.0)
+    assert np.all(sigma > 0.0)
+
+
+def test_regime_detect_hmm_prefers_temporal_backend_payload() -> None:
+    raw = _unwrap(regime_detect)
+    history = _history_from_returns(
+        np.concatenate([np.full(30, -0.002), np.full(30, 0.002)])
+    )
+    gamma = np.vstack(
+        [
+            np.tile(np.array([[0.98, 0.02]]), (30, 1)),
+            np.tile(np.array([[0.03, 0.97]]), (30, 1)),
+        ]
+    )
+    weights = np.array([0.5, 0.5])
+    mu = np.array([-0.002, 0.002])
+    sigma = np.array([0.001, 0.0015])
+
+    with (
+        patch("mtdata.core.regime._fetch_history", return_value=history),
+        patch("mtdata.core.regime._resolve_denoise_base_col", return_value="close"),
+        patch("mtdata.core.regime._format_time_minimal", side_effect=lambda x: f"T{x}"),
+        patch(
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
+            return_value=(weights, mu, sigma, gamma, {"backend": "gaussian_hmm"}),
+        ) as mock_hmm,
+        patch(
+            "mtdata.core.regime.api.fit_gaussian_mixture_1d",
+            side_effect=AssertionError("fallback should not run"),
+            create=True,
+        ),
+    ):
+        out = raw(
+            symbol="TEST",
+            timeframe="H1",
+            limit=len(history),
+            method="hmm",
+            params={"n_states": 2},
+            detail="full",
+            include_series=True,
+        )
+
+    mock_hmm.assert_called_once()
+    assert out["success"] is True
+    assert out["params_used"]["backend"] == "gaussian_hmm"
+    assert out["params_used"]["temporal_model"] is True
+    assert out["regime_params"]["mu"] == pytest.approx([-0.002, 0.002])
+    assert len(out["series"]["state_probabilities"]) == len(history) - 1
+
+
+def test_regime_detect_hmm_fallback_is_explicit() -> None:
+    raw = _unwrap(regime_detect)
+    history = _history_from_returns(np.full(40, 0.001))
+    gamma = np.tile(np.array([[1.0, 0.0]]), (40, 1))
+    weights = np.array([1.0])
+    mu = np.array([0.001])
+    sigma = np.array([0.0005])
+
+    with (
+        patch("mtdata.core.regime._fetch_history", return_value=history),
+        patch("mtdata.core.regime._resolve_denoise_base_col", return_value="close"),
+        patch("mtdata.core.regime._format_time_minimal", side_effect=lambda x: f"T{x}"),
+        patch(
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "mtdata.forecast.monte_carlo.fit_gaussian_mixture_1d",
+            return_value=(weights, mu, sigma, gamma, 12.5),
+            create=True,
+        ),
+    ):
+        out = raw(
+            symbol="TEST",
+            timeframe="H1",
+            limit=len(history),
+            method="hmm",
+            detail="full",
+        )
+
+    assert out["success"] is True
+    assert out["params_used"]["backend"] == "gaussian_mixture_fallback"
+    assert out["params_used"]["temporal_model"] is False
+    assert out["params_used"]["fallback_reason"] == "boom"
+    assert "fell back" in " ".join(out.get("warnings", [])).lower()

--- a/tests/core/test_regime_output_semantics.py
+++ b/tests/core/test_regime_output_semantics.py
@@ -618,7 +618,7 @@ def test_gmm_alias_reports_requested_method_and_common_reliability() -> None:
         patch("mtdata.core.regime._resolve_denoise_base_col", return_value="close"),
         patch("mtdata.core.regime._format_time_minimal", side_effect=lambda x: f"T{x}"),
         patch(
-            "mtdata.core.regime.api.fit_gaussian_mixture_1d",
+            "mtdata.core.regime.fit_temporal_gaussian_hmm_1d",
             return_value=(weights, mu, sigma, gamma, None),
             create=True,
         ),


### PR DESCRIPTION
## Summary
- replace the regime hmm path with a true temporal Gaussian HMM fit backed by hmmlearn when available
- keep payload semantics stable while surfacing explicit backend/fallback metadata and warnings if the code must fall back to the old Gaussian-mixture behavior
- add focused tests for the temporal backend helper, the regime_detect temporal path, and the explicit fallback path

## Testing
- python -m pytest tests\\core\\test_regime_hmm_temporal.py tests\\core\\test_regime_output_semantics.py::test_gmm_alias_reports_requested_method_and_common_reliability tests\\core\\test_regime_defaults_business_logic.py::test_regime_detect_rejects_invalid_min_regime_bars tests\\core\\test_regime_defaults_business_logic.py::test_regime_detect_default_min_regime_bars_is_dynamic tests\\core\\test_regime_core_coverage.py::TestRegimeDetectHMM