### PR TITLE
utils: add adaptive numba fast paths

### DIFF
--- a/src/mtdata/utils/denoise/filters/adaptive.py
+++ b/src/mtdata/utils/denoise/filters/adaptive.py
@@ -6,8 +6,13 @@ import pandas as pd
 
 from ..base import _series_like, register_filter
 
+try:
+    from numba import njit as _numba_njit
+except Exception:
+    _numba_njit = None  # type: ignore[assignment]
 
-def _adaptive_lms_filter(
+
+def _adaptive_lms_filter_python(
     x: np.ndarray,
     order: int,
     mu: float,
@@ -41,6 +46,90 @@ def _adaptive_lms_filter(
     return y
 
 
+if _numba_njit is not None:
+    @_numba_njit(cache=True)
+    def _adaptive_lms_filter_numba(
+        x: np.ndarray,
+        order: int,
+        mu: float,
+        eps: float = 1e-6,
+        leak: float = 0.0,
+        use_bias: bool = True,
+    ) -> np.ndarray:
+        n = len(x)
+        k = max(1, int(order))
+        if n < k + 1 or mu <= 0.0:
+            return x
+        leak_val = leak if leak > 0.0 else 0.0
+        if use_bias:
+            w = np.zeros(k + 1, dtype=np.float64)
+            for j in range(1, k + 1):
+                w[j] = 1.0 / float(k)
+        else:
+            w = np.empty(k, dtype=np.float64)
+            for j in range(k):
+                w[j] = 1.0 / float(k)
+        y = x.copy()
+        for t in range(k, n):
+            y_hat = 0.0
+            denom = eps
+            if use_bias:
+                y_hat = w[0]
+                denom += 1.0
+                for j in range(k):
+                    sample = x[t - 1 - j]
+                    y_hat += w[j + 1] * sample
+                    denom += sample * sample
+            else:
+                for j in range(k):
+                    sample = x[t - 1 - j]
+                    y_hat += w[j] * sample
+                    denom += sample * sample
+            y[t] = y_hat
+            err = x[t] - y_hat
+            step = mu / denom
+            if use_bias:
+                w[0] = (1.0 - leak_val) * w[0] + step * err
+                for j in range(k):
+                    sample = x[t - 1 - j]
+                    w[j + 1] = (1.0 - leak_val) * w[j + 1] + step * err * sample
+            else:
+                for j in range(k):
+                    sample = x[t - 1 - j]
+                    w[j] = (1.0 - leak_val) * w[j] + step * err * sample
+        return y
+else:
+    _adaptive_lms_filter_numba = None
+
+
+def _adaptive_lms_filter(
+    x: np.ndarray,
+    order: int,
+    mu: float,
+    eps: float = 1e-6,
+    leak: float = 0.0,
+    use_bias: bool = True,
+) -> np.ndarray:
+    x_arr = np.asarray(x, dtype=float)
+    if _adaptive_lms_filter_numba is not None:
+        return _adaptive_lms_filter_numba(
+            x_arr,
+            int(order),
+            float(mu),
+            float(eps),
+            float(leak),
+            bool(use_bias),
+        )
+    return _adaptive_lms_filter_python(
+        x_arr,
+        order=order,
+        mu=mu,
+        eps=eps,
+        leak=leak,
+        use_bias=use_bias,
+    )
+
+
 @register_filter('lms')
 def _denoise_lms_series(
     s: pd.Series,
@@ -64,7 +153,7 @@ def _denoise_lms_series(
     return _series_like(s, y)
 
 
-def _adaptive_rls_filter(
+def _adaptive_rls_filter_python(
     x: np.ndarray,
     order: int,
     lam: float,
@@ -102,6 +191,102 @@ def _adaptive_rls_filter(
         w = w + k_gain * err
         p = (p - np.outer(k_gain, x_vec) @ p) / lam_val
     return y
+
+
+if _numba_njit is not None:
+    @_numba_njit(cache=True)
+    def _adaptive_rls_filter_numba(
+        x: np.ndarray,
+        order: int,
+        lam: float,
+        delta: float,
+        use_bias: bool = True,
+    ) -> np.ndarray:
+        n = len(x)
+        k = max(1, int(order))
+        if n < k + 1 or lam <= 0.0 or lam > 1.0:
+            return x
+        delta_val = delta if delta > 1e-6 else 1e-6
+        dim = k + 1 if use_bias else k
+        w = np.zeros(dim, dtype=np.float64)
+        start = 1 if use_bias else 0
+        for j in range(start, dim):
+            w[j] = 1.0 / float(k)
+        p = np.zeros((dim, dim), dtype=np.float64)
+        inv_delta = 1.0 / delta_val
+        for i in range(dim):
+            p[i, i] = inv_delta
+        y = x.copy()
+        x_vec = np.empty(dim, dtype=np.float64)
+        px = np.empty(dim, dtype=np.float64)
+        k_gain = np.empty(dim, dtype=np.float64)
+        xp = np.empty(dim, dtype=np.float64)
+        p_new = np.empty((dim, dim), dtype=np.float64)
+        for t in range(k, n):
+            if use_bias:
+                x_vec[0] = 1.0
+                for j in range(k):
+                    x_vec[j + 1] = x[t - 1 - j]
+            else:
+                for j in range(k):
+                    x_vec[j] = x[t - 1 - j]
+            for i in range(dim):
+                total = 0.0
+                for j in range(dim):
+                    total += p[i, j] * x_vec[j]
+                px[i] = total
+            denom = lam
+            for i in range(dim):
+                denom += x_vec[i] * px[i]
+            if denom <= 0.0:
+                y[t] = x[t]
+                continue
+            for i in range(dim):
+                k_gain[i] = px[i] / denom
+            y_hat = 0.0
+            for i in range(dim):
+                y_hat += w[i] * x_vec[i]
+            y[t] = y_hat
+            err = x[t] - y_hat
+            for i in range(dim):
+                w[i] = w[i] + k_gain[i] * err
+            for j in range(dim):
+                total = 0.0
+                for m in range(dim):
+                    total += x_vec[m] * p[m, j]
+                xp[j] = total
+            for i in range(dim):
+                for j in range(dim):
+                    p_new[i, j] = (p[i, j] - k_gain[i] * xp[j]) / lam
+            p[:, :] = p_new
+        return y
+else:
+    _adaptive_rls_filter_numba = None
+
+
+def _adaptive_rls_filter(
+    x: np.ndarray,
+    order: int,
+    lam: float,
+    delta: float,
+    use_bias: bool = True,
+) -> np.ndarray:
+    x_arr = np.asarray(x, dtype=float)
+    if _adaptive_rls_filter_numba is not None:
+        return _adaptive_rls_filter_numba(
+            x_arr,
+            int(order),
+            float(lam),
+            float(delta),
+            bool(use_bias),
+        )
+    return _adaptive_rls_filter_python(
+        x_arr,
+        order=order,
+        lam=lam,
+        delta=delta,
+        use_bias=use_bias,
+    )
 
 
 @register_filter('rls')

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -19,6 +19,7 @@ from mtdata.utils.denoise.filters.adaptive import (
     _adaptive_rls_filter,
 )
 from mtdata.utils.denoise.filters.decomposition import _ssa_denoise, _vmd_denoise
+from mtdata.utils.denoise.filters import adaptive as adaptive_filters
 from mtdata.utils.denoise.filters import specialized as specialized_filters
 from mtdata.utils.denoise.filters.specialized import (
     _bilateral_filter_1d,
@@ -905,6 +906,30 @@ class TestAdaptiveLmsFilter:
         y = _adaptive_lms_filter(NOISY_SIGNAL, order=5, mu=0.5, leak=0.01)
         _check_basic(y, N)
 
+    def test_uses_accelerated_path_when_available(self, monkeypatch):
+        x = np.linspace(0.0, 1.0, 8)
+
+        def fake_accel(values, order, mu, eps, leak, use_bias):
+            assert order == 3
+            assert mu == 0.2
+            assert eps == 1e-6
+            assert leak == 0.1
+            assert use_bias is False
+            return np.full_like(values, 42.0)
+
+        monkeypatch.setattr(adaptive_filters, "_adaptive_lms_filter_numba", fake_accel)
+
+        result = adaptive_filters._adaptive_lms_filter(
+            x,
+            order=3,
+            mu=0.2,
+            eps=1e-6,
+            leak=0.1,
+            use_bias=False,
+        )
+
+        np.testing.assert_array_equal(result, np.full_like(x, 42.0))
+
 
 class TestAdaptiveRlsFilter:
     def test_basic(self):
@@ -918,6 +943,28 @@ class TestAdaptiveRlsFilter:
     def test_invalid_lambda_returns_input(self):
         y = _adaptive_rls_filter(NOISY_SIGNAL, order=5, lam=1.5, delta=1.0)
         np.testing.assert_array_equal(y, NOISY_SIGNAL)
+
+    def test_uses_accelerated_path_when_available(self, monkeypatch):
+        x = np.linspace(-1.0, 1.0, 8)
+
+        def fake_accel(values, order, lam, delta, use_bias):
+            assert order == 4
+            assert lam == 0.95
+            assert delta == 0.5
+            assert use_bias is True
+            return np.full_like(values, -3.0)
+
+        monkeypatch.setattr(adaptive_filters, "_adaptive_rls_filter_numba", fake_accel)
+
+        result = adaptive_filters._adaptive_rls_filter(
+            x,
+            order=4,
+            lam=0.95,
+            delta=0.5,
+            use_bias=True,
+        )
+
+        np.testing.assert_array_equal(result, np.full_like(x, -3.0))
 
 
 class TestSsaDenoise:


### PR DESCRIPTION
## Summary
- add optional numba-backed LMS and RLS implementations for the adaptive denoise filters
- keep the existing Python implementations as the mandatory fallback when numba is unavailable
- add focused tests that verify accelerated-path dispatch and rerun the denoise test module

## Validation
- python -m pytest tests\\utils\\test_denoise_pure.py -q