### PR TITLE
utils: taper lowpass fft transitions

### DIFF
--- a/src/mtdata/utils/denoise/filters/spectral.py
+++ b/src/mtdata/utils/denoise/filters/spectral.py
@@ -14,6 +14,32 @@ except Exception:
 from ..base import _series_like, register_filter
 
 
+def _lowpass_fft_weights(n_bins: int, cutoff_ratio: float) -> np.ndarray:
+    if n_bins <= 0:
+        return np.zeros(0, dtype=float)
+    try:
+        cutoff = float(cutoff_ratio)
+    except Exception:
+        cutoff = 0.1
+    if cutoff <= 0:
+        weights = np.zeros(n_bins, dtype=float)
+        weights[0] = 1.0
+        return weights
+    if cutoff >= 1:
+        return np.ones(n_bins, dtype=float)
+    cutoff_bins = max(1, min(n_bins, int(n_bins * cutoff)))
+    if cutoff_bins >= n_bins:
+        return np.ones(n_bins, dtype=float)
+    transition_bins = min(n_bins - cutoff_bins, max(1, int(np.ceil(cutoff_bins * 0.25))))
+    weights = np.zeros(n_bins, dtype=float)
+    weights[:cutoff_bins] = 1.0
+    if transition_bins <= 0:
+        return weights
+    taper = 0.5 * (1.0 + np.cos(np.pi * np.arange(1, transition_bins + 1) / float(transition_bins + 1)))
+    weights[cutoff_bins : cutoff_bins + transition_bins] = taper
+    return weights
+
+
 @register_filter('lowpass_fft')
 def _denoise_lowpass_fft_series(
     s: pd.Series,
@@ -22,11 +48,12 @@ def _denoise_lowpass_fft_series(
     causality: str,
 ) -> pd.Series:
     del causality
+    if len(x) == 0:
+        return _series_like(s, x)
     cutoff_ratio = float(params.get('cutoff_ratio', 0.1))
     X = np.fft.rfft(x)
-    kmax = int(len(X) * cutoff_ratio)
-    Y = np.zeros_like(X)
-    Y[:max(1, kmax)] = X[:max(1, kmax)]
+    weights = _lowpass_fft_weights(len(X), cutoff_ratio)
+    Y = X * weights
     y = np.fft.irfft(Y, n=len(x))
     return _series_like(s, y)
 

--- a/tests/utils/test_denoise_pure.py
+++ b/tests/utils/test_denoise_pure.py
@@ -26,7 +26,7 @@ from mtdata.utils.denoise.filters.specialized import (
     _kalman_filter_1d,
     _tv_denoise_1d,
 )
-from mtdata.utils.denoise.filters.spectral import _butterworth_filter
+from mtdata.utils.denoise.filters.spectral import _butterworth_filter, _lowpass_fft_weights
 from mtdata.utils.denoise.filters.trend import (
     _beta_irls_mean,
     _beta_smooth,
@@ -286,6 +286,32 @@ class TestDenoiseSeriesDispatch:
         result = _denoise_series(s, method="lowpass_fft", params={"cutoff_ratio": 0.1})
         _check_basic(result.values, N)
         assert _smoothness(result.values) < _smoothness(NOISY_SIGNAL)
+
+    def test_lowpass_fft_reduces_step_ringing_vs_brick_wall(self):
+        step = np.concatenate([np.zeros(128), np.ones(128)])
+        s = _make_series(step)
+
+        tapered = _denoise_series(s, method="lowpass_fft", params={"cutoff_ratio": 0.1}).to_numpy()
+
+        spectrum = np.fft.rfft(step)
+        brick = np.zeros_like(spectrum)
+        keep = max(1, int(len(spectrum) * 0.1))
+        brick[:keep] = spectrum[:keep]
+        brick_wall = np.fft.irfft(brick, n=len(step))
+
+        tapered_ringing = max(0.0, float(np.max(tapered) - 1.0)) + max(0.0, float(-np.min(tapered)))
+        brick_ringing = max(0.0, float(np.max(brick_wall) - 1.0)) + max(0.0, float(-np.min(brick_wall)))
+
+        assert tapered_ringing < brick_ringing
+
+    def test_lowpass_fft_weights_taper_after_cutoff(self):
+        weights = _lowpass_fft_weights(32, 0.25)
+
+        assert weights[0] == pytest.approx(1.0)
+        np.testing.assert_allclose(weights[:8], np.ones(8))
+        assert np.all((weights >= 0.0) & (weights <= 1.0))
+        assert np.all(np.diff(weights[8:]) <= 1e-12)
+        assert np.any((weights[8:] > 0.0) & (weights[8:] < 1.0))
 
     def test_hp(self):
         s = _make_series(NOISY_SIGNAL)


### PR DESCRIPTION
## Summary
- replace the lowpass_fft brick-wall mask with a smooth FFT taper while keeping the same API
- preserve edge cases such as empty input and clipped cutoff handling
- add focused ringing/weight tests and rerun the denoise test module

## Validation
- python -m pytest tests\\utils\\test_denoise_pure.py -q